### PR TITLE
KATHA-2339: Changes Related To Job Scheduling

### DIFF
--- a/src/.env.sample
+++ b/src/.env.sample
@@ -158,3 +158,9 @@ SESSION_MENTEE_LIMIT=25
 
 # Mentor screct code for registering
 MENTOR_SECRET_CODE=4567
+
+# Scheduler service host
+SCHEDULER_SERVICE_HOST="http://localhost:4000"
+
+# Scheduler service base url
+SCHEDULER_SERVICE_BASE_URL= '/scheduler/'

--- a/src/constants/common.js
+++ b/src/constants/common.js
@@ -87,4 +87,27 @@ module.exports = {
 	MEDIUM: 'medium',
 	RECOMMENDED_FOR: 'recommended_for',
 	CATEGORIES: 'categories',
+	jobsToCreate: [
+		{
+			jobId: 'mentoring_session_one_hour_',
+			jobName: 'notificationBeforeAnHour',
+			emailTemplate: 'mentor_one_hour_before_session_reminder',
+		},
+		{
+			jobId: 'mentoring_session_one_day_',
+			jobName: 'notificationBeforeOneDay',
+			emailTemplate: 'mentor_session_reminder',
+		},
+		{
+			jobId: 'mentoring_session_fifteen_min_',
+			jobName: 'notificationBeforeFifteenMin',
+			emailTemplate: 'mentee_session_reminder',
+		},
+	],
+	notificationJobIdPrefixes : [
+		'mentoring_session_one_hour_',
+		'mentoring_session_one_day_',
+		'mentoring_session_fifteen_min_'
+	]
 }
+ 

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -8,4 +8,9 @@ module.exports = {
 	USERS_LIST: 'v1/account/list',
 	SHARE_MENTOR_PROFILE: 'v1/user/share',
 	USERS_ENTITY_READ: 'v1/userentity/read',
+
+	// Endpoints of the scheduler service
+    CREATE_SCHEDULER_JOB: '/scheduler/jobs/create', 	// Create scheduler job endpoint
+    UPDATE_DELAY: '/scheduler/jobs/updateDelay', 		// Update delay of scheduled job endpoint
+    REMOVE_SCHEDULED_JOB: '/scheduler/jobs/remove' 	// Remove scheduled job endpoint
 }

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -10,7 +10,7 @@ module.exports = {
 	USERS_ENTITY_READ: 'v1/userentity/read',
 
 	// Endpoints of the scheduler service
-    CREATE_SCHEDULER_JOB: '/scheduler/jobs/create', 	// Create scheduler job endpoint
-    UPDATE_DELAY: '/scheduler/jobs/updateDelay', 		// Update delay of scheduled job endpoint
-    REMOVE_SCHEDULED_JOB: '/scheduler/jobs/remove' 	// Remove scheduled job endpoint
+    CREATE_SCHEDULER_JOB: 'jobs/create', 	// Create scheduler job endpoint
+    UPDATE_DELAY: 'jobs/updateDelay', 		// Update delay of scheduled job endpoint
+    REMOVE_SCHEDULED_JOB: 'jobs/remove' 	// Remove scheduled job endpoint
 }

--- a/src/controllers/v1/notifications.js
+++ b/src/controllers/v1/notifications.js
@@ -6,56 +6,22 @@
  */
 
 // Dependencies
-const notificationsHelper = require('@services/helper/notifications')
+const notificationsService = require('@services/helper/notifications')
 const httpStatusCode = require('@generics/http-status')
 
 module.exports = class Notifications {
 	/**
-	 * Notification email cron job before 15min.
-	 * @method
-	 * @name emailCronJobBeforeFifteenMin
-	 * @returns {JSON} - Send email notification.
+	 * @description			- Notification email cron job.
+	 * @method				- post
+	 * @name 				- emailCronJob
+	 * @returns {JSON} 		- Send email notification.
 	 */
 
-	async emailCronJobBeforeFifteenMin() {
+	async emailCronJob(req) {
 		try {
-			notificationsHelper.sendNotificationBefore15mins()
-			return {
-				statusCode: httpStatusCode.ok,
-			}
-		} catch (error) {
-			return error
-		}
-	}
 
-	/**
-	 * Notification email cron job before 24hrs.
-	 * @method
-	 * @name emailCronJobBeforeOneDay
-	 * @returns {JSON} - Send email notification.
-	 */
-
-	async emailCronJobBeforeOneDay() {
-		try {
-			notificationsHelper.sendNotificationBefore24Hour()
-			return {
-				statusCode: httpStatusCode.ok,
-			}
-		} catch (error) {
-			return error
-		}
-	}
-
-	/**
-	 * Notification email cron job before 1hr.
-	 * @method
-	 * @name emailCronJobBeforeOneHour
-	 * @returns {JSON} - Send email notification.
-	 */
-
-	async emailCronJobBeforeOneHour() {
-		try {
-			notificationsHelper.sendNotificationBefore1Hour()
+			// Make a call to notification service 
+			notificationsService.sendEmail(req.body.jobId, req.body.emailTemplateCode)
 			return {
 				statusCode: httpStatusCode.ok,
 			}

--- a/src/controllers/v1/notifications.js
+++ b/src/controllers/v1/notifications.js
@@ -21,7 +21,7 @@ module.exports = class Notifications {
 		try {
 
 			// Make a call to notification service 
-			notificationsService.sendEmail(req.body.jobId, req.body.emailTemplateCode)
+			notificationsService.sendNotification(req.body.jobId, req.body.emailTemplateCode)
 			return {
 				statusCode: httpStatusCode.ok,
 			}

--- a/src/envVariables.js
+++ b/src/envVariables.js
@@ -195,6 +195,14 @@ let enviromentVariables = {
 		message: 'Required mentor secret code',
 		optional: false,
 	},
+	SCHEDULER_SERVICE_HOST: {
+		message: 'Required scheduler service host',
+		optional: false,
+	},
+	SCHEDULER_SERVICE_BASE_URL: {
+		message: 'Required scheduler service base url',
+		optional: false,
+	},
 }
 
 let success = true

--- a/src/generics/utils.js
+++ b/src/generics/utils.js
@@ -172,6 +172,28 @@ const epochFormat = (date, format) => {
 	return moment.unix(date).utc().format(format)
 }
 
+/**
+ * Calculate the time difference in milliseconds between a current date
+ * and a modified date obtained by subtracting a specified time value and unit from startDate.
+ * 
+ * @param {string} startDate - The start date.
+ * @param {number} timeValue - The amount of time to subtract.
+ * @param {string} timeUnit - The unit of time to subtract (e.g., 'hours', 'days').
+ * @returns {number} The time difference in milliseconds.
+ */
+function getTimeDifferenceInMilliseconds(startDate, timeValue, timeUnit) {
+	// Get current date
+	const currentUnixTimestamp = moment().unix()
+
+	// Subtract the specified time value and unit
+	const modifiedDate = moment.unix(startDate).subtract(timeValue, timeUnit).unix()
+
+	// Calculate the duration and get the time difference in milliseconds
+	const duration = moment.duration(moment.unix(modifiedDate).diff(moment.unix(currentUnixTimestamp)));
+
+	return duration.asMilliseconds()
+}
+
 module.exports = {
 	hash: hash,
 	getCurrentMonthRange: getCurrentMonthRange,
@@ -195,4 +217,5 @@ module.exports = {
 	isAMentor,
 	isNumeric: isNumeric,
 	epochFormat: epochFormat,
+	getTimeDifferenceInMilliseconds,getTimeDifferenceInMilliseconds
 }

--- a/src/package.json
+++ b/src/package.json
@@ -99,6 +99,7 @@
 		"@routes": "routes",
 		"@services": "services",
 		"@validators": "validators",
-		"@database": "database"
+		"@database": "database",
+		"@requests": "requests"
 	}
 }

--- a/src/requests/scheduler.js
+++ b/src/requests/scheduler.js
@@ -1,0 +1,161 @@
+/**
+ * Name: scheduler.js
+ * Author: Vishnu
+ * Created Date: 28-Sept-2023
+ * Description: Interaction with Elevate-scheduler service.
+ */
+
+// Dependencies
+const request = require('request');
+const apiEndpoints = require('@constants/endpoints');
+const schedulerServiceUrl = process.env.SCHEDULER_SERVICE_URL;
+const email = [process.env.SCHEDULER_SERVICE_ERROR_REPORTING_EMAIL_ID];
+const mentoringBaseurl = `http://localhost:${process.env.APPLICATION_PORT}`;
+
+/**
+ * Create a scheduler job.
+ *
+ * @param {string} jobId - The unique identifier for the job.
+ * @param {number} delay - The delay in milliseconds before the job is executed.
+ * @param {string} jobName - The name of the job.
+ * @param {string} notificationTemplate - The template for the notification.
+ * @returns {Promise} A promise that resolves with the result of the job creation.
+ */
+const createSchedulerJob = function (jobId, delay, jobName, notificationTemplate) {
+    return new Promise(async (resolve, reject) => {
+        const bodyData = {
+            jobName: jobName,
+            email: email,
+            request: {
+                url: mentoringBaseurl + '/mentoring/v1/notifications/emailCronJob',
+                method: 'post',
+                header: { internal_access_token: process.env.INTERNAL_ACCESS_TOKEN },
+            },
+            jobOptions: {
+                jobId: jobId,
+                delay: delay,
+                emailTemplate: notificationTemplate,
+                removeOnComplete: true,
+                removeOnFail: false,
+                attempts: 1
+            }
+        };
+
+        const options = {
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            json: bodyData
+        };
+
+        const apiUrl = schedulerServiceUrl + apiEndpoints.CREATE_SCHEDULER_JOB;
+        try {
+            request.post(apiUrl, options, callback);
+
+            function callback(err, data) {
+                if (err) {
+                    reject({
+                        message: 'SCHEDULER_SERVICE_DOWN',
+                    });
+                } else {
+                    if (data.body.success) {
+                        resolve(data.body.message)
+                    } else {
+                        reject({
+                            message: 'NOTIFICATION_SCHEDULE_FAILED',
+                        });
+                    }
+
+                }
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+
+/**
+ * Update the delay of a scheduled job.
+ *
+ * @param {object} bodyData - The data containing information about the job.
+ * @returns {Promise} A promise that resolves with the result of the job update.
+ */
+const updateDelayOfScheduledJob = function (bodyData) {
+    return new Promise(async (resolve, reject) => {
+        const options = {
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            json: bodyData
+        };
+
+        const apiUrl = schedulerServiceUrl + apiEndpoints.UPDATE_DELAY;
+        try {
+            request.post(apiUrl, options, callback);
+
+            function callback(err, data) {
+                if (err) {
+                    reject({
+                        message: 'SCHEDULER_SERVICE_DOWN',
+                    });
+                } else {
+                    if (data.body.success) {
+                        resolve(data.body.message)
+                    } else {
+                        reject({
+                            message: 'SCHEDULER_SERVICE_DOWN',
+                        });
+                    }
+                }
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+
+/**
+ * Remove a scheduled job.
+ *
+ * @param {object} bodyData - The data containing information about the job.
+ * @returns {Promise} A promise that resolves with the result of the job removal.
+ */
+const removeScheduledJob = function (bodyData) {
+    return new Promise(async (resolve, reject) => {
+        const options = {
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            json: bodyData
+        };
+
+        const apiUrl = schedulerServiceUrl + apiEndpoints.REMOVE_SCHEDULED_JOB;
+        try {
+            request.post(apiUrl, options, callback);
+
+            function callback(err, data) {
+                if (err) {
+                    reject({
+                        message: 'SCHEDULER_SERVICE_DOWN',
+                    });
+                } else {
+                    if (data.body.success) {
+                        resolve(data.body.message)
+                    } else {
+                        reject({
+                            message: 'SCHEDULER_SERVICE_DOWN',
+                        });
+                    }
+                }
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+
+module.exports = {
+    createSchedulerJob: createSchedulerJob,
+    updateDelayOfScheduledJob: updateDelayOfScheduledJob,
+    removeScheduledJob: removeScheduledJob
+};

--- a/src/requests/scheduler.js
+++ b/src/requests/scheduler.js
@@ -8,7 +8,7 @@
 // Dependencies
 const request = require('request');
 const apiEndpoints = require('@constants/endpoints');
-const schedulerServiceUrl = process.env.SCHEDULER_SERVICE_URL;
+const schedulerServiceUrl = process.env.SCHEDULER_SERVICE_HOST + process.env.SCHEDULER_SERVICE_BASE_URL;
 const email = [process.env.SCHEDULER_SERVICE_ERROR_REPORTING_EMAIL_ID];
 const mentoringBaseurl = `http://localhost:${process.env.APPLICATION_PORT}`;
 

--- a/src/services/helper/notifications.js
+++ b/src/services/helper/notifications.js
@@ -1,139 +1,96 @@
 // Dependenices
-const moment = require('moment-timezone')
 const common = require('@constants/common')
-const sessionData = require('@db/sessions/queries')
-const notificationData = require('@db/notification-template/query')
-const sessionAttendesData = require('@db/sessionAttendees/queries')
 const sessionAttendeesHelper = require('./sessionAttendees')
-const ObjectId = require('mongoose').Types.ObjectId
 const kafkaCommunication = require('@generics/kafka-communication')
 const utils = require('@generics/utils')
+const sessionQueries = require('@database/queries/sessions')
+const notificationQueries = require('@database/queries/notificationTemplate')
+const sessionAttendeesQueries = require('@database/queries/sessionAttendees')
+
 
 module.exports = class Notifications {
 	/**
-	 * Send Notification to Mentors before 24 hour.
+	 * @description				- Send Notifications.
 	 * @method
-	 * @name sendNotificationBefore24Hour
+	 * @name 					- sendNotification
 	 * @returns
 	 */
 
-	static async sendNotificationBefore24Hour() {
+	static async sendNotification(notificationJobId, notificataionTemplate) {
 		try {
-			let currentDateutc = moment().utc().format(common.UTC_DATE_TIME_FORMAT)
-			var dateEndTime = moment(currentDateutc).add(1441, 'minutes').format(common.UTC_DATE_TIME_FORMAT)
-			var dateStartTime = moment(currentDateutc).add(1440, 'minutes').format(common.UTC_DATE_TIME_FORMAT)
-
-			let sessions = await sessionData.findSessions({
-				status: 'published',
-				deleted: false,
-				startDateUtc: {
-					$gte: dateStartTime,
-					$lt: dateEndTime,
-				},
+			// Data contains notificationJobId and notificationTemplate.
+			// Extract sessionId from incoming notificationJobId.
+			// Split the string by underscores and get the last part
+			const parts = notificationJobId.split('_')
+			const lastPart = parts[parts.length - 1]
+			
+			// Convert the last part to an integer
+			const sessionId = Number(lastPart)
+			
+			// Find session data
+			let sessions = await sessionQueries.findOne({
+				id: sessionId,
+				status: common.PUBLISHED_STATUS
 			})
 
-			let emailTemplate = await notificationData.findOneEmailTemplate(common.MENTOR_SESSION_REMAINDER_EMAIL_CODE)
-
-			if (emailTemplate && sessions && sessions.length > 0) {
-				const mentorIds = []
-				sessions.forEach((session) => {
-					mentorIds.push(session.userId.toString())
-				})
-				const userAccounts = await sessionAttendeesHelper.getAllAccountsDetail(mentorIds)
-				if (userAccounts && userAccounts.result.length > 0) {
-					await Promise.all(
-						sessions.map(async function (session) {
-							let emailBody = emailTemplate.body
-							if (
-								process.env.DEFAULT_MEETING_SERVICE.toUpperCase() != common.BBB_VALUE &&
-								!session.meetingInfo?.link
-							) {
-								emailBody = utils.extractEmailTemplate(emailBody, ['default', 'linkWarning'])
-							} else {
-								emailBody = utils.extractEmailTemplate(emailBody, ['default'])
-							}
-							emailBody = emailBody.replace('{sessionTitle}', session.title)
-							var foundElement = userAccounts.result.find((e) => e._id === session.userId.toString())
-
-							if (foundElement && foundElement.email.address && foundElement.name) {
-								emailBody = emailBody.replace('{name}', foundElement.name)
-								const payload = {
-									type: 'email',
-									email: {
-										to: foundElement.email.address,
-										subject: emailTemplate.subject,
-										body: emailBody,
-									},
-								}
-								await kafkaCommunication.pushEmailToKafka(payload)
-							}
-						})
-					)
+			// Get email template based on incoming request.
+			let emailTemplate = await notificationQueries.findOneEmailTemplate(notificataionTemplate)
+			
+			if ( emailTemplate && sessions ) {				
+				// if notificataionTemplate is {MENTEE_SESSION_REMAINDER_EMAIL_CODE} then notification to all personal registered for the session has to be send.
+				if (notificataionTemplate === common.MENTEE_SESSION_REMAINDER_EMAIL_CODE) {
+					await this.sendNotificationToAttendees(sessions, emailTemplate)
+				} else {
+					await this.sendNotificationsToMentor(sessions, emailTemplate)
 				}
 			}
+				
 		} catch (error) {
 			throw error
 		}
 	}
 
 	/**
-	 * Send Notification to attendees before 15 mins.
+	 * @description 		- Send Notification to attendees.
 	 * @method
-	 * @name sendNotificationBefore15mins
+	 * @name 				- sendNotificationToAttendees
 	 * @returns
 	 */
 
-	static async sendNotificationBefore15mins() {
+	static async sendNotificationToAttendees(session, emailTemplate) {
 		try {
-			let currentDateutc = moment().utc().format(common.UTC_DATE_TIME_FORMAT)
-
-			var dateEndTime = moment(currentDateutc).add(16, 'minutes').format(common.UTC_DATE_TIME_FORMAT)
-			var dateStartTime = moment(currentDateutc).add(15, 'minutes').format(common.UTC_DATE_TIME_FORMAT)
-
-			let data = await sessionData.findSessions({
-				status: 'published',
-				deleted: false,
-				startDateUtc: {
-					$gte: dateStartTime,
-					$lt: dateEndTime,
-				},
-			})
-
-			let allAttendess = []
+			let allAttendees = []
 			let attendeesInfo = []
-
-			let emailTemplate = await notificationData.findOneEmailTemplate(common.MENTEE_SESSION_REMAINDER_EMAIL_CODE)
-
-			if (emailTemplate && data && data.length > 0) {
-				await Promise.all(
-					data.map(async function (session) {
-						const sessionAttendees = await sessionAttendesData.findAllSessionAttendees({
-							sessionId: ObjectId(session._id),
-						})
-						if (sessionAttendees && sessionAttendees.length > 0) {
-							sessionAttendees.forEach((attendee) => {
-								allAttendess.push(attendee.userId.toString())
-								attendeesInfo.push({
-									userId: attendee.userId.toString(),
-									title: session.title,
-								})
-							})
-						}
+			
+			// Get all sessionAttendees joined for the session
+			const sessionAttendees = await sessionAttendeesQueries.findAll({
+				session_id: session.id,
+			})
+			
+			// If sessionAttendees data is available process the data
+			if (sessionAttendees && sessionAttendees.length > 0) {
+				sessionAttendees.forEach((attendee) => {
+					allAttendees.push(attendee.mentee_id)
+					attendeesInfo.push({
+						userId: attendee.mentee_id,
+						title: session.title,
 					})
-				)
+				})
 			}
-			const attendeesAccounts = await sessionAttendeesHelper.getAllAccountsDetail(allAttendess)
-
+			
+			// Get attendees accound details
+			const attendeesAccounts = await sessionAttendeesHelper.getAllAccountsDetail(allAttendees)
+			
 			if (attendeesAccounts.result && attendeesAccounts.result.length > 0) {
 				attendeesInfo.forEach(async function (attendee) {
 					let emailBody = emailTemplate.body.replace('{sessionTitle}', attendee.title)
-					var foundElement = attendeesAccounts.result.find((e) => e._id === attendee.userId.toString())
-					if (foundElement && foundElement.email.address && foundElement.name) {
+					var foundElement = attendeesAccounts.result.find((e) => e.id === attendee.userId)
+					if (foundElement && foundElement.email && foundElement.name) {
 						emailBody = emailBody.replace('{name}', foundElement.name)
 						const payload = {
 							type: 'email',
 							email: {
-								to: foundElement.email.address,
+								to: foundElement.email,
 								subject: emailTemplate.subject,
 								body: emailBody,
 							},
@@ -142,76 +99,56 @@ module.exports = class Notifications {
 					}
 				})
 			}
+			
 		} catch (error) {
 			throw error
 		}
 	}
 
 	/**
-	 * Send Notification to Mentors before 1 hour.
+	 * @description			- Send Notification to Mentors.
 	 * @method
-	 * @name sendNotificationBefore1Hour
+	 * @name 				- sendNotificationsToMentor
 	 * @returns
 	 */
 
-	static async sendNotificationBefore1Hour() {
+	static async sendNotificationsToMentor(session, emailTemplate) {
 		try {
-			let currentDateutc = moment().utc().format(common.UTC_DATE_TIME_FORMAT)
-			var dateEndTime = moment(currentDateutc).add(61, 'minutes').format(common.UTC_DATE_TIME_FORMAT)
-			var dateStartTime = moment(currentDateutc).add(60, 'minutes').format(common.UTC_DATE_TIME_FORMAT)
-
-			let sessions = await sessionData.findSessions({
-				status: 'published',
-				deleted: false,
-				startDateUtc: {
-					$gte: dateStartTime,
-					$lt: dateEndTime,
-				},
-			})
-
-			let emailTemplate = await notificationData.findOneEmailTemplate(
-				common.MENTOR_SESSION_ONE_HOUR_REMAINDER_EMAIL_CODE
-			)
-
-			if (emailTemplate && sessions && sessions.length > 0) {
-				const mentorIds = []
-				sessions.forEach((session) => {
-					mentorIds.push(session.userId.toString())
-				})
-				const userAccounts = await sessionAttendeesHelper.getAllAccountsDetail(mentorIds)
-				if (userAccounts && userAccounts.result.length > 0) {
-					await Promise.all(
-						sessions.map(async function (session) {
-							let emailBody = emailTemplate.body
-							if (
-								process.env.DEFAULT_MEETING_SERVICE.toUpperCase() != 'BBB' &&
-								!session.meetingInfo?.link
-							) {
-								emailBody = utils.extractEmailTemplate(emailBody, ['default', 'linkWarning'])
-							} else {
-								emailBody = utils.extractEmailTemplate(emailBody, ['default'])
-							}
-							emailBody = emailBody.replace('{sessionTitle}', session.title)
-							var foundElement = userAccounts.result.find((e) => e._id === session.userId.toString())
-
-							if (foundElement && foundElement.email.address && foundElement.name) {
-								emailBody = emailBody.replace('{name}', foundElement.name)
-								const payload = {
-									type: 'email',
-									email: {
-										to: foundElement.email.address,
-										subject: emailTemplate.subject,
-										body: emailBody,
-									},
-								}
-								await kafkaCommunication.pushEmailToKafka(payload)
-							}
-						})
-					)
+			const mentorIds = []
+			mentorIds.push(session.mentor_id.toString())
+			
+			// Get mentor details
+			const userAccounts = await sessionAttendeesHelper.getAllAccountsDetail(mentorIds)
+			
+			if (userAccounts && userAccounts.result.length > 0) {
+				const userAccountDetails = userAccounts.result[0]
+				let emailBody = emailTemplate.body
+				if (
+					process.env.DEFAULT_MEETING_SERVICE.toUpperCase() != common.BBB_VALUE &&
+					!session.meetingInfo?.link
+				) {
+					emailBody = utils.extractEmailTemplate(emailBody, ['default', 'linkWarning'])
+				} else {
+					emailBody = utils.extractEmailTemplate(emailBody, ['default'])
+				}
+				emailBody = emailBody.replace('{sessionTitle}', session.title)
+				if ( userAccountDetails && userAccountDetails.email && userAccountDetails.name ) {
+					emailBody = emailBody.replace('{name}', userAccountDetails.name)
+					const payload = {
+						type: 'email',
+						email: {
+							to: userAccountDetails.email,
+							subject: emailTemplate.subject,
+							body: emailBody,
+						},
+					}
+					await kafkaCommunication.pushEmailToKafka(payload)
 				}
 			}
+
 		} catch (error) {
 			throw error
 		}
 	}
+
 }

--- a/src/services/helper/sessions.js
+++ b/src/services/helper/sessions.js
@@ -1,25 +1,21 @@
 // Dependencies
-const ObjectId = require('mongoose').Types.ObjectId
 const _ = require('lodash')
 const moment = require('moment-timezone')
 const httpStatusCode = require('@generics/http-status')
 const apiEndpoints = require('@constants/endpoints')
 const common = require('@constants/common')
 const sessionData = require('@db/sessions/queries')
-const sessionAttendesData = require('@db/sessionAttendees/queries')
 const notificationTemplateData = require('@db/notification-template/query')
 const sessionAttendeesHelper = require('./sessionAttendees')
 const kafkaCommunication = require('@generics/kafka-communication')
 const apiBaseUrl = process.env.USER_SERIVCE_HOST + process.env.USER_SERIVCE_BASE_URL
 const request = require('request')
-
 const bigBlueButton = require('./bigBlueButton')
 const userProfile = require('./userProfile')
 const utils = require('@generics/utils')
 const sessionMentor = require('./mentors')
 const sessionQueries = require('@database/queries/sessions')
 const sessionAttendeesQueries = require('@database/queries/sessionAttendees')
-const menteeExtensionQueries = require('@database/queries/userextension')
 const mentorExtensionQueries = require('../../database/queries/mentorextension')
 const sessionEnrollmentQueries = require('@database/queries/sessionEnrollments')
 const postSessionQueries = require('@database/queries/postSessionDetail')
@@ -27,6 +23,8 @@ const sessionOwnershipQueries = require('@database/queries/sessionOwnership')
 const entityTypeQueries = require('@database/queries/entityType')
 const entitiesQueries = require('@database/queries/entity')
 const { Op } = require('sequelize')
+
+const schedulerRequest = require('@requests/scheduler')
 
 module.exports = class SessionsHelper {
 	/**
@@ -49,7 +47,7 @@ module.exports = class SessionsHelper {
 					responseCode: 'CLIENT_ERROR',
 				})
 			}
-
+			
 			const timeSlot = await this.isTimeSlotAvailable(loggedInUserId, bodyData.start_date, bodyData.end_date)
 			if (timeSlot.isTimeSlotAvailable === false) {
 				return common.failureResponse({
@@ -145,16 +143,37 @@ module.exports = class SessionsHelper {
 
 			bodyData['mentor_org_id'] =
 				mentorDetails.organisation_ids.length > 0 ? mentorDetails.organisation_ids[0] : null
-
+			
 			const data = await sessionQueries.create(bodyData)
 			await sessionOwnershipQueries.create({
 				mentor_id: loggedInUserId,
 				session_id: data.id,
 			})
-
+			
 			await this.setMentorPassword(data.id, data.mentor_id)
 			await this.setMenteePassword(data.id, data.created_at)
 
+			// Set notification schedulers for the session
+			let jobsToCreate = common.jobsToCreate
+
+			// Calculate delays for notification jobs
+			jobsToCreate[0].delay = await utils.getTimeDifferenceInMilliseconds(bodyData.start_date, 1, 'hour')
+			jobsToCreate[1].delay = await utils.getTimeDifferenceInMilliseconds(bodyData.start_date, 24, 'hour')
+			jobsToCreate[2].delay = await utils.getTimeDifferenceInMilliseconds(bodyData.start_date, 15, 'minutes')
+
+			// Iterate through the jobs and create scheduler jobs
+			for ( let jobIndex = 0; jobIndex < jobsToCreate.length; jobIndex++ ) {
+				// Append the session ID to the job ID
+				jobsToCreate[jobIndex].jobId = jobsToCreate[jobIndex].jobId + data.id
+				// Create the scheduler job with the calculated delay and other parameters
+				await schedulerRequest.createSchedulerJob(
+					jobsToCreate[jobIndex].jobId, 
+					jobsToCreate[jobIndex].delay, 
+					jobsToCreate[jobIndex].jobName, 
+					jobsToCreate[jobIndex].emailTemplate
+				)
+			}
+			
 			return common.successResponse({
 				statusCode: httpStatusCode.created,
 				message: 'SESSION_CREATED_SUCCESSFULLY',
@@ -298,6 +317,7 @@ module.exports = class SessionsHelper {
 			}
 
 			let message
+			const sessionRelatedJobIds = common.notificationJobIdPrefixes.map(element => element + sessionDetail.id);
 			if (method == common.DELETE_METHOD) {
 				let statTime = moment.unix(sessionDetail.start_date)
 				const current = moment.utc()
@@ -308,6 +328,13 @@ module.exports = class SessionsHelper {
 						id: sessionId,
 					})
 					message = 'SESSION_DELETED_SUCCESSFULLY'
+
+					// Delete scheduled jobs associated with deleted session
+					for ( let jobIndex = 0; jobIndex < sessionRelatedJobIds.length; jobIndex++ ) {
+						// Remove scheduled notification jobs using the jobIds
+						await schedulerRequest.removeScheduledJob({ jobId: sessionRelatedJobIds[jobIndex] })
+					}
+
 				} else {
 					return common.failureResponse({
 						message: 'SESSION_DELETION_FAILED',
@@ -325,6 +352,21 @@ module.exports = class SessionsHelper {
 					})
 				}
 				message = 'SESSION_UPDATED_SUCCESSFULLY'
+
+				// If new start date is passed update session notification jobs
+				if ( bodyData.start_date && bodyData.start_date !== sessionDetail.start_date ) {
+					const updateDelayData = sessionRelatedJobIds.map(jobId => ({ id: jobId }));
+
+					// Calculate new delays for notification jobs
+					updateDelayData[0].delay = await utils.getTimeDifferenceInMilliseconds(bodyData.start_date, 1, 'hour')
+					updateDelayData[1].delay = await utils.getTimeDifferenceInMilliseconds(bodyData.start_date, 24, 'hour')
+					updateDelayData[2].delay = await utils.getTimeDifferenceInMilliseconds(bodyData.start_date, 15, 'minutes')
+
+					// Update scheduled notification job delays
+					for ( let jobIndex = 0; jobIndex < updateDelayData.length; jobIndex++ ) {
+						await schedulerRequest.updateDelayOfScheduledJob(updateDelayData[jobIndex])
+					}
+				}
 			}
 
 			if (method == common.DELETE_METHOD || isSessionReschedule) {

--- a/src/validators/v1/notifications.js
+++ b/src/validators/v1/notifications.js
@@ -1,0 +1,14 @@
+/**
+ * name : validators/v1/notifications.js
+ * author : Vishnu
+ * Date : 01-Oct-2023
+ * Description : Validations of notification controller
+ */
+
+module.exports = {
+	emailCronJob: (req) => {
+        // Validate incoming request body
+		req.checkBody('jobId').notEmpty().withMessage('jobId field is empty')
+		req.checkBody('emailTemplateCode').notEmpty().withMessage('emailTemplateCode field is empty')
+	},
+}


### PR DESCRIPTION
The PR includes changes related to **KATHA-2339.** You can find more details about this task at [Task-2339](https://katha.shikshalokam.org/task-view-2339.html)."

**### Brief of Changes:**

- Added a new API endpoint to the notification controller for elevate-scheduler service to call.
- Safely removed three old API endpoints.
- Implemented logic to call mentor and mentee notifications.
- Added request module and endpoints for mentor service's communication with the scheduler service.
- Made environmental key changes.

**### .env Changes Required for Task 2339:**

Two new environment keys need to be added (sample provided below):
**SCHEDULER_SERVICE_HOST="http://localhost:4000/"
SCHEDULER_SERVICE_BASE_URL= '/scheduler/'**


Reminder to Check: After these changes, we may no longer need migration scripts scheduler.js and bull.js. If so, we can also remove one existing .env variable, SCHEDULER_SERVICE_URL."