### PR TITLE
[BUG: 1193]made changes to pass internal access token to user/read API call

### DIFF
--- a/src/requests/user.js
+++ b/src/requests/user.js
@@ -57,11 +57,10 @@ const details = function (token = '', userId = '') {
 	return new Promise(async (resolve, reject) => {
 		try {
 			let profileUrl = userBaseUrl + endpoints.USER_PROFILE_DETAILS
-			let internalToken = false
+			let internalToken = true // All internal api calls require internal access token
 
 			if (userId != '') {
 				profileUrl = profileUrl + '/' + userId
-				internalToken = true
 			}
 			const profileDetails = await requests.get(profileUrl, token, internalToken)
 			return resolve(profileDetails)


### PR DESCRIPTION
Reason: Changes were implemented in the services to enforce the requirement of an internal access token for all internal API calls. As a result, this specific internal API call was not including the necessary token, leading to an unauthorized response from the user service.