### PR TITLE
Migration for updating the lable in entity for value Published to Upcoming

### DIFF
--- a/src/database/migrations/20240206131021-update-entities-published-label.js
+++ b/src/database/migrations/20240206131021-update-entities-published-label.js
@@ -1,0 +1,14 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+	async up(queryInterface, Sequelize) {
+		// Update entities with value 'PUBLISHED' to 'Upcoming'
+		await queryInterface.bulkUpdate('entities', { label: 'Upcoming' }, { value: 'PUBLISHED' })
+	},
+
+	async down(queryInterface, Sequelize) {
+		// Revert the update if needed (rollback)
+		await queryInterface.bulkUpdate('entities', { label: 'Published' }, { label: 'Upcoming' })
+	},
+}


### PR DESCRIPTION
The "Status" is displaying as "published" instead of "Upcoming" also "edit" and "delete" option is visible,post session timing is started in "session list" page. Katha #1196