### PR TITLE
[BUG-1258] - Edited session- mentor email send condition change for manager created session 

### DIFF
--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -767,10 +767,10 @@ module.exports = class SessionsHelper {
 						}
 					}
 				})
-				// send mail to mentor if session is created and handled by a manager
+				// send mail to mentor if session is created and handled by a manager and if there is any data change
 				// send notification only if front end request for user notification
 				// notifyUser ---> this key is added for above purpose
-				if (isSessionCreatedByManager && notifyUser) {
+				if (method == common.DELETE_METHOD || (notifyUser && isSessionDataChanged)) {
 					let response = await this.pushSessionRelatedMentorEmailToKafka(
 						mentorEmailTemplate,
 						orgId,

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -770,7 +770,10 @@ module.exports = class SessionsHelper {
 				// send mail to mentor if session is created and handled by a manager and if there is any data change
 				// send notification only if front end request for user notification
 				// notifyUser ---> this key is added for above purpose
-				if (method == common.DELETE_METHOD || (notifyUser && isSessionDataChanged)) {
+				if (
+					(method == common.DELETE_METHOD && isSessionCreatedByManager) ||
+					(notifyUser && isSessionDataChanged)
+				) {
 					let response = await this.pushSessionRelatedMentorEmailToKafka(
 						mentorEmailTemplate,
 						orgId,


### PR DESCRIPTION
Ticket : https://katha.shikshalokam.org/bug-view-1258.html
Reason: Front end is calling session/update even if there is no data change. During this call mentor edit email was called. which is not expected. fixed by adding correct condition