### PR TITLE
Change to product and service names in the setup guides.

### DIFF
--- a/documentation/2.6.1/MentorEd-Env-Modification-README.md
+++ b/documentation/2.6.1/MentorEd-Env-Modification-README.md
@@ -1,16 +1,20 @@
-# MentorEd Environment Variable Modification Guide
+# Environment Variable Modification Guide
 
 ## Overview
 
-The existing MentorEd documentation and setup guides include a set of environment files with default environment variables. These serve as an excellent starting point for any deployment and offer a fully operational MentorEd application for you to explore. However, as expected, certain features may be impaired without replacing the default environment variables with adopter-specific values. For example, variables related to notification email services and cloud file upload.
+The existing documentation and setup guides include a set of environment files with default environment variables. These serve as an excellent starting point for any deployment and offer a fully operational Mentor application for you to explore. 
 
-This document acts as a reference for such functionalities/features and their related environment variables.
+However, as expected, certain features may be impaired without replacing the default environment variables with adopter-specific values. For example, variables related to notification email services and cloud file upload.
+
+This document acts as a reference for such functionalities or features and their related environment variables.
 
 ## Affected Features
 
-1. **User SignUp**
+1. **User Signup**
 
-    Since an email with an OTP code is sent to verify the email ID provided during the signup process, the notification service environment variables must be configured with real values sourced from an email service. Currently, MentorEd's notification service natively supports Sendgrid as the default email service. Therefore, the following environment variables must be set for this feature to function properly.
+    Since an email with an OTP code is sent to verify the email ID provided during the signup process, the Notification service environment variables must be configured with real values sourced from an email service. 
+    
+    Currently, the Notification service natively supports [Twilio® SendGrid](https://sendgrid.com/en-us) as the default email service. Therefore, the following environment variables must be set for this feature to function properly.
 
     ### Notification Service
 
@@ -25,17 +29,13 @@ This document acts as a reference for such functionalities/features and their re
     SENDGRID_FROM_EMAIL
     ```
 
-    > **Note:** If the **APPLICATION_ENV** in the user service is set to "**development**," the OTP code will be logged in the console. This feature might be advantageous in a local setup as it bypasses the need for a Sendgrid account. Logging is disabled in production environments (**APPLICATION_ENV=production**).
-
-    ### Relevant Resources
-
-    1. [Twilio SendGrid](https://sendgrid.com/en-us)
+    > **Note:** If the **APPLICATION_ENV** in the User service is set to "**development**," the OTP code will be logged in the console. This feature might be advantageous in a local setup as it bypasses the need for a Sendgrid account. Logging is disabled in production environments (**APPLICATION_ENV=production**).
 
 2. **File Upload**
 
-    MentorEd utilises file upload functionality to implement several features like profile and session image upload, bulk user creation and bulk session creation. Therefore it is expected that you have a bucket configured with a cloud provider of your choosing (AWS, GCP, AZURE or OCI). And relevant environment fields are set in the following services.
+    The application utilizes file upload functionality to implement several features like profile and session image upload, bulk user creation and bulk session creation. Therefore, it is expected that you have a bucket configured with a cloud provider of your choosing (AWS, GCP, AZURE, or OCI). And relevant environment fields are set in the following services.
 
-    ### Mentoring & User Services
+    ### Mentor and User Services
 
     **Docker Setup:** `mentoring_env`, `user_env`
 
@@ -80,17 +80,17 @@ This document acts as a reference for such functionalities/features and their re
 
 3. **Support Emails**
 
-    MentorEd provides a mechanism for users to generate request emails that are sent to a support team overseeing user requests. For example, if a user wants to delete their account or report an issue, they can trigger an email with their request message from the portal.
+    The application provides a mechanism for users to generate request emails that are sent to a support team overseeing user requests. For example, if a user wants to delete their account or report an issue, they can trigger an email with their request message from the portal.
 
     <div style="text-align: left; width: 100%;">
-        <h4 style="text-align: left;">MentorEd Report Issue Help Page</h4>
+        <h4 style="text-align: left;">Report Issue Help Page</h4>
         <img src="../../public/images/help_report_issue.png" alt="MentorEd Report Issue Help Page" 
             style="max-width: 100%; height: auto; width: auto; max-height: 300px;">
     </div>
 
-    For this feature to function, support email IDs and other values must be set in the mentoring service as listed below.
+    For this feature to function, support email IDs and other values must be set in the Mentor service as listed below.
 
-    ### Mentoring Service
+    ### Mentor Service
 
     **Docker Setup:** `mentoring_env`
 
@@ -103,11 +103,11 @@ This document acts as a reference for such functionalities/features and their re
     ENABLE_EMAIL_FOR_REPORT_ISSUE			-> Already enabled in default/sample env files
     ```
 
-    > **IMPORTANT:** As a prerequisite, the notification service must be configured with the proper SendGrid environment variables, as shown in the User SignUp section.
+    > **Important:** As a prerequisite, the Notification service must be configured with the proper SendGrid environment variables, as shown in the User SignUp section.
 
 4. **Email Encryption**
 
-    Since version 2.6.1, MentorEd has enhanced its security by implementing system-wide email encryption, now enabled by default. This update ensures that email IDs are not stored as plaintext in the database. Instead, they are encrypted using the `AES-256-CBC` algorithm. The encryption and decryption processes are governed by the following environment variables:
+    Since version 2.6.1, the application has enhanced its security by implementing system-wide email encryption, now enabled by default. This update ensures that email IDs are not stored as plaintext in the database. Instead, they are encrypted using the `AES-256-CBC` algorithm. The encryption and decryption processes are governed by the following environment variables:
 
     ### User Service
 
@@ -122,15 +122,15 @@ This document acts as a reference for such functionalities/features and their re
     EMAIL_ID_ENCRYPTION_IV
     ```
 
-    > **CRITICAL:** The default environment files provided with the deployment guide contain default but valid values for the encryption variables mentioned above. It is crucial to replace these default values with unique ones for your deployment to ensure the security of your data. Failing to do so exposes you to the risk of using a publicly available KEY and IV pair for encrypting your email IDs.
+    > **Critical:** The default environment files provided with the deployment guide contain default but valid values for the email encryption variables. Replace these default values with unique ones for your deployment to avoid the risk of using a publicly available KEY and IV pair for encrypting your email IDs.
 
     To generate a new, valid pair of KEY and IV, you can use the following script: [Generate Encryption Keys](https://github.com/ELEVATE-Project/user/blob/master/src/scripts/generateEncyrptionKeys.js).
 
 5. **CAPTCHA**
 
-    Since version 2.6.1, MentorEd has introduced the option to implement CAPTCHA using [Google reCAPTCHA](https://www.google.com/recaptcha/about/) on various portal pages such as Login and SignUp. By default, this feature is disabled in the configuration settings found in the default environment files included in the deployment guide.
+    Since version 2.6.1, the application has introduced the option to implement CAPTCHA using [Google reCAPTCHA](https://www.google.com/recaptcha/about/) on various portal pages such as Login and SignUp. By default, this feature is disabled in the configuration settings found in the default environment files included in the deployment guide.
 
-    If you wish to enable CAPTCHA, you will need to obtain a `site key` and `secret key` from Google. To do this, follow the instructions provided in the [reCAPTCHA Developer Guide](https://developers.google.com/recaptcha/intro). Once you have your keys, update the following environment variables to activate CAPTCHA on your site.
+    If you wish to enable CAPTCHA, you need to obtain a `site key` and `secret key` from Google. To do this, follow the instructions provided in the [reCAPTCHA Developer Guide](https://developers.google.com/recaptcha/intro). Once you have your keys, update the following environment variables to activate CAPTCHA on your site.
 
     ### User Service
 
@@ -159,7 +159,7 @@ This document acts as a reference for such functionalities/features and their re
 
 6. **Session Management**
 
-    Since version 2.6.1, MentorEd has implemented advanced features for user session management, such as inactivity timeouts, session tracking, and remote logout. These features are controlled by the following environment variables:
+    Since version 2.6.1, the application includes advanced features for user session management, such as inactivity timeouts, session tracking, and remote logout. These features are controlled by the following environment variables:
 
     ### User Service
 
@@ -182,7 +182,7 @@ This document acts as a reference for such functionalities/features and their re
 
 7. **Rate Limiting**
 
-    Since version 2.6.1, Elevate has implemented rate-limiting to enhance system stability and prevent abuse. This feature regulates the number of requests a user can make to the services within a given timeframe. Rate-limiting is enabled by default.
+    The rate-limiting feature has been introduced in version 2.6.1 to enhance system stability and prevent abuse. This feature regulates the number of requests a user can make to the services within a given timeframe. Rate-limiting is enabled by default.
 
     ### User Service
 
@@ -197,4 +197,4 @@ This document acts as a reference for such functionalities/features and their re
     RATE_LIMITER_ENABLED
     ```
 
-    Refer to the [MentorEd Rate-Limiting Guide](./MentorEd-Rate-Limiting-Guide.md) for more information on how to set these variables.
+    Refer to the [Rate-Limiting Guide](./MentorEd-Rate-Limiting-Guide.md) for more information on how to set these variables.

--- a/documentation/2.6.1/MentorEd-Rate-Limiting-Guide.md
+++ b/documentation/2.6.1/MentorEd-Rate-Limiting-Guide.md
@@ -1,8 +1,8 @@
-# Developer Guide: Elevate Rate-Limiting Overview
+# Developer Guide: Rate-Limiting Overview
 
 ## Introduction
 
-Elevate Rate-Limiting aims to efficiently manage the flow of requests to our services and prevent misuse. It employs the express-rate-limit middleware and is primarily enforced at the interface service level, serving as the gateway to all our services. This guide provides detailed instructions and necessary configurations for integrating rate limiters in the development environment.
+Rate-Limiting aims to efficiently manage the flow of requests to our services and prevent misuse. It employs the express-rate-limit middleware and is primarily enforced at the interface service level, serving as the gateway to all our services. This guide provides detailed instructions and necessary configurations for integrating rate limiters in the development environment.
 
 ## Rate Limiting Strategy
 

--- a/documentation/2.6.1/dockerized/MentorEd-Setup-README.md
+++ b/documentation/2.6.1/dockerized/MentorEd-Setup-README.md
@@ -1,10 +1,16 @@
-## Dockerized Services & Dependencies
+## Dockerized Services and Dependencies
 
-Expectation: Upon following the prescribed steps, you will achieve a fully operational MentorEd application setup, complete with both the portal and backend services.
+Expectation: Upon following the prescribed steps, you will achieve a fully operational Mentor application setup, complete with both the portal and backend services.
 
 ## Prerequisites
 
-To set up the MentorEd application, ensure you have Docker and Docker Compose installed on your system. For Ubuntu users, detailed installation instructions for both can be found in the documentation here: [How To Install and Use Docker Compose on Ubuntu](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-compose-on-ubuntu-20-04). For Windows and MacOS users, you can refer to the Docker documentation for installation instructions: [Docker Compose Installation Guide](https://docs.docker.com/compose/install/). Once these prerequisites are in place, you're all set to get started with setting up the MentorEd application.
+To set up the application, you must install Docker and Docker Compose on your system using any one of the following ways:
+ 
+* Ubuntu users can refer to [How To Install and Use Docker Compose on Ubuntu](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-compose-on-ubuntu-20-04) for detailed installation instructions. 
+
+* Windows and MacOS users can refer to the [Docker Compose Installation Guide](https://docs.docker.com/compose/install/) for the installation instructions.
+
+Once these prerequisites are in place, you're all set to get started with setting up the application.
 
 ## Installation
 
@@ -18,7 +24,7 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
     curl -OJL https://github.com/ELEVATE-Project/mentoring/raw/master/documentation/2.6.1/dockerized/docker-compose-mentoring.yml
     ```
 
-    > Note: All commands are run from the mentoring directory.
+    > **Note:** Run all the commands from the mentoring directory.
 
     Directory structure:
 
@@ -53,9 +59,9 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
 
     > **Note:** Modify the environment files as necessary for your deployment using any text editor, ensuring that the values are appropriate for your environment. The default values provided in the current files are functional and serve as a good starting point. Refer to the sample env files provided at the [Mentoring](https://github.com/ELEVATE-Project/mentoring/blob/master/src/.env.sample), [User](https://github.com/ELEVATE-Project/user/blob/master/src/.env.sample), [Notification](https://github.com/ELEVATE-Project/notification/blob/master/src/.env.sample), [Scheduler](https://github.com/ELEVATE-Project/scheduler/blob/master/src/.env.sample), and [Interface](https://github.com/ELEVATE-Project/interface-service/blob/main/src/.env.sample) repositories for reference.
 
-    > **Caution:** While the default values in the downloaded environment files enable the MentorEd Application to operate, certain features may not function correctly or could be impaired unless the adopter-specific environment variables are properly configured.
+    > **Caution:** While the default values in the downloaded environment files enable the application to operate, certain features may not function correctly or could be impaired unless the adopter-specific environment variables are properly configured.
     >
-    > For detailed instructions on adjusting these values, please consult the **[MentorEd Environment Variable Modification Guide](https://github.com/ELEVATE-Project/mentoring/blob/master/documentation/2.6.1/MentorEd-Env-Modification-README.md)**.
+    > For detailed instructions on adjusting these values, please consult the **[Environment Variable Modification Guide](https://github.com/ELEVATE-Project/mentoring/blob/master/documentation/2.6.1/MentorEd-Env-Modification-README.md)**.
 
     > **Important:** As mentioned in the above linked document, the **User SignUp** functionality may be compromised if key environment variables are not set correctly during deployment. If you opt to skip this setup, consider using the sample user account generator detailed in the `Sample User Accounts Generation` section of this document.
 
@@ -98,7 +104,7 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
         >
         > \- /home/joffin/elevate/backend/environment.ts:/app/src/environments/environment.ts
 
-6.  **Download `docker-compose-up` & `docker-compose-down` Script Files**
+6.  **Download `docker-compose-up` and `docker-compose-down` Script Files**
 
     -   **Ubuntu/Linux/Mac**
 
@@ -132,7 +138,7 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
         curl -OJL https://github.com/ELEVATE-Project/mentoring/raw/master/documentation/2.6.1/dockerized/scripts/windows/docker-compose-down.bat
         ```
 
-7.  **Run All Services & Dependencies:** All services and dependencies can be started using the `docker-compose-up` script file.
+7.  **Run All Services and Dependencies:** All services and dependencies can be started using the `docker-compose-up` script file.
 
     -   **Ubuntu/Linux/Mac**
         ```
@@ -148,9 +154,9 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
 
         > **Note**: During the first Docker Compose run, the database, migration seeder files, and the script to set the default organization will be executed automatically.
 
-8.  **Access The MentorEd Application**: Once the services are up and the front-end app bundle is built successfully, navigate to **[localhost:8100](http://localhost:8100/)** to access the MentorEd app.
-9.  **Gracefully Stop All Services & Dependencies:** All containers which are part of the docker-compose can be gracefully stopped by pressing `Ctrl + c` in the same terminal where the services are running.
-10. **Remove All Service & Dependency Containers**: All docker containers can be stopped and removed by using the `docker-compose-down` file.
+8.  **Access The Application**: Once the services are up and the front-end app bundle is built successfully, navigate to **[localhost:8100](http://localhost:8100/)** to access the application.
+9.  **Gracefully Stop All Services and Dependencies:** All containers which are part of the docker-compose can be gracefully stopped by pressing `Ctrl + c` in the same terminal where the services are running.
+10. **Remove All Service and Dependency Containers**: All docker containers can be stopped and removed by using the `docker-compose-down` file.
 
     -   **Ubuntu/Linux/Mac**
         ```
@@ -166,11 +172,11 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
 
 ## Enable Citus Extension
 
-MentorEd relies on PostgreSQL as its core database system. To boost performance and scalability, users can opt to enable the Citus extension. This transforms PostgreSQL into a distributed database, spreading data across multiple nodes to handle large datasets more efficiently as demand grows.
+The application relies on PostgreSQL as its core database system. To boost performance and scalability, users can opt to enable the Citus extension. This transforms PostgreSQL into a distributed database, spreading data across multiple nodes to handle large datasets more efficiently as demand grows.
 
 For more information, refer **[Citus Data](https://www.citusdata.com/)**.
 
-To enable the Citus extension for mentoring and user services, follow these steps.
+To enable the Citus extension for Mentor and User services, follow these steps.
 
 1. Create a sub-directory named `mentoring` and download `distributionColumns.sql` into it.
     ```
@@ -255,9 +261,9 @@ By implementing these adjustments, the configuration ensures that when the `dock
 
 ## Sample User Accounts Generation
 
-During the initial setup of MentorEd services with the default configuration, you may encounter issues creating new accounts through the regular SignUp flow on the MentorEd portal. This typically occurs because the default SignUp process includes OTP verification to prevent abuse. Until the notification service is configured correctly to send actual emails, you will not be able to create new accounts.
+During the initial setup of Mentor services with the default configuration, you may encounter issues creating new accounts through the regular Signup flow on the Mentor portal. This typically occurs because the default SignUp process includes OTP verification to prevent abuse. Until the notification service is configured correctly to send actual emails, you will not be able to create new accounts.
 
-In such cases, you can generate sample user accounts using the steps below. This allows you to explore the MentorEd services and portal immediately after setup.
+In such cases, you can generate sample user accounts using the steps below. This allows you to explore the services and portal immediately after setup.
 
 > **Warning:** Use this generator only immediately after the initial system setup and before any normal user accounts are created through the portal. It should not be used under any circumstances thereafter.
 

--- a/documentation/2.6.1/native/MentorEd-Setup-README.md
+++ b/documentation/2.6.1/native/MentorEd-Setup-README.md
@@ -1,10 +1,10 @@
 ## PM2 Managed Services & Natively Installed Dependencies
 
-Expectation: Upon following the prescribed steps, you will achieve a fully operational MentorEd application setup. Both the portal and backend services are managed using PM2, with all dependencies installed natively on the host system.
+Expectation: Upon following the prescribed steps, you will achieve a fully operational Mentor application setup. Both the portal and backend services are managed using PM2, with all dependencies installed natively on the host system.
 
 ## Prerequisites
 
-Before setting up the following MentorEd application, dependencies given below should be installed and verified to be running. Refer to the steps given below to install them and verify.
+Before setting up the application, the dependencies should be installed and verified to be running. Refer to the following steps to install them and verify:
 
 -   **Ubuntu/Linux**
 
@@ -111,7 +111,7 @@ Before setting up the following MentorEd application, dependencies given below s
 
         1. Adapt the instructions given in the following ["Apache Kafka on Windows"](https://www.conduktor.io/kafka/how-to-install-apache-kafka-on-windows/) documentation to install Kafka version 3.5.0.
 
-            > Note: As per the instructions, Kafka server and Zookeeper has to be kept active on different WSL terminals for the entire lifetime of MentorEd services.
+            > Note: As per the instructions, Kafka server and Zookeeper has to be kept active on different WSL terminals for the entire lifetime of Mentor services.
 
             > Note: Multiple WSL terminals can be opened by launching `Ubuntu` from start menu.
 
@@ -265,9 +265,9 @@ Before setting up the following MentorEd application, dependencies given below s
 
     > **Note:** Modify the environment files as necessary for your deployment using any text editor, ensuring that the values are appropriate for your environment. The default values provided in the current files are functional and serve as a good starting point. Refer to the sample env files provided at the [Mentoring](https://github.com/ELEVATE-Project/mentoring/blob/master/src/.env.sample), [User](https://github.com/ELEVATE-Project/user/blob/master/src/.env.sample), [Notification](https://github.com/ELEVATE-Project/notification/blob/master/src/.env.sample), [Scheduler](https://github.com/ELEVATE-Project/scheduler/blob/master/src/.env.sample), and [Interface](https://github.com/ELEVATE-Project/interface-service/blob/main/src/.env.sample) repositories for reference.
 
-    > **Caution:** While the default values in the downloaded environment files enable the MentorEd Application to operate, certain features may not function correctly or could be impaired unless the adopter-specific environment variables are properly configured.
+    > **Caution:** While the default values in the downloaded environment files enable the application to operate, certain features may not function correctly or could be impaired unless the adopter-specific environment variables are properly configured.
     >
-    > For detailed instructions on adjusting these values, please consult the **[MentorEd Environment Variable Modification Guide](https://github.com/ELEVATE-Project/mentoring/blob/master/documentation/2.6.1/MentorEd-Env-Modification-README.md)**.
+    > For detailed instructions on adjusting these values, please consult the **[Environment Variable Modification Guide](https://github.com/ELEVATE-Project/mentoring/blob/master/documentation/2.6.1/MentorEd-Env-Modification-README.md)**.
 
     > **Important:** As mentioned in the above linked document, the **User SignUp** functionality may be compromised if key environment variables are not set correctly during deployment. If you opt to skip this setup, consider using the sample user account generator detailed in the `Sample User Accounts Generation` section of this document.
 
@@ -341,9 +341,9 @@ Before setting up the following MentorEd application, dependencies given below s
 
 7. **Enabling Citus And Setting Distribution Columns (Optional)**
 
-    MentorEd relies on PostgreSQL as its core database system. To boost performance and scalability, users can opt to enable the Citus extension. This transforms PostgreSQL into a distributed database, spreading data across multiple nodes to handle large datasets more efficiently as demand grows.
+    The application relies on PostgreSQL as its core database system. To boost performance and scalability, users can opt to enable the Citus extension. This transforms PostgreSQL into a distributed database, spreading data across multiple nodes to handle large datasets more efficiently as demand grows.
 
-    > NOTE: Currently only available for Linux based operation systems.
+    > **Note:** Currently only available for Linux based operation systems.
 
     1. Download mentoring `distributionColumns.sql` file.
 
@@ -383,7 +383,7 @@ Before setting up the following MentorEd application, dependencies given below s
                 ```
 
 8. **Insert Initial Data**
-   Use MentorEd in-build seeders to insert the initial data.
+   Use the application's in-build seeders to insert the initial data.
 
     - **Ubuntu/Linux/MacOS**
 
@@ -400,7 +400,7 @@ Before setting up the following MentorEd application, dependencies given below s
 
 9. **Start The Services**
 
-    Following the steps given below, 2 instances of each MentorEd backend service will be deployed and be managed by PM2 process manager.
+    Following the steps given below, 2 instances of each Mentor backend service will be deployed and be managed by PM2 process manager.
 
     - **Ubuntu/Linux**
 
@@ -450,7 +450,7 @@ Before setting up the following MentorEd application, dependencies given below s
 
 11. **Start The Portal**
 
-    MentorEd portal utilizes Ionic and Angular CLI for building the browser bundle, follow the steps given below to install them and start the portal.
+    The portal utilizes Ionic and Angular CLI for building the browser bundle, follow the steps given below to install them and start the portal.
 
     - **Ubuntu/Linux**
 
@@ -545,13 +545,13 @@ Before setting up the following MentorEd application, dependencies given below s
             pm2 start pm2.config.json & cd ..
             ```
 
-    Navigate to http://localhost:7601 to access the MentorEd Portal.
+    Navigate to http://localhost:7601 to access the portal.
 
 ## Sample User Accounts Generation
 
-During the initial setup of MentorEd services with the default configuration, you may encounter issues creating new accounts through the regular SignUp flow on the MentorEd portal. This typically occurs because the default SignUp process includes OTP verification to prevent abuse. Until the notification service is configured correctly to send actual emails, you will not be able to create new accounts.
+During the initial setup of Mentor services with the default configuration, you may encounter issues creating new accounts through the regular Signup flow on the Mentor portal. This typically occurs because the default SignUp process includes OTP verification to prevent abuse. Until the notification service is configured correctly to send actual emails, you will not be able to create new accounts.
 
-In such cases, you can generate sample user accounts using the steps below. This allows you to explore the MentorEd services and portal immediately after setup.
+In such cases, you can generate sample user accounts using the steps below. This allows you to explore the services and portal immediately after setup.
 
 > **Warning:** Use this generator only immediately after the initial system setup and before any normal user accounts are created through the portal. It should not be used under any circumstances thereafter.
 

--- a/documentation/README-Template.md
+++ b/documentation/README-Template.md
@@ -166,7 +166,7 @@ This project relies on the following services:
 
 Please follow the setup guide provided with each service to ensure proper configuration. While these are the recommended services, feel free to utilize any alternative microservices that better suit your project's requirements.
 
-For a comprehensive overview of the MentorEd implementation, refer to the [MentorEd Documentation](https://elevate-docs.shikshalokam.org/.mentorEd/intro).
+For a comprehensive overview of the implementation, refer to the [Mentor Documentation](https://elevate-docs.shikshalokam.org/mentor/intro).
 
 The source code for the frontend/mobile application can be found in its respective [GitHub repository](https://github.com/ELEVATE-Project/mentoring-mobile-app).
 

--- a/documentation/latest/MentorEd-Env-Modification-README.md
+++ b/documentation/latest/MentorEd-Env-Modification-README.md
@@ -1,16 +1,20 @@
-# MentorEd Environment Variable Modification Guide
+# Environment Variable Modification Guide
 
 ## Overview
 
-The existing MentorEd documentation and setup guides include a set of environment files with default environment variables. These serve as an excellent starting point for any deployment and offer a fully operational MentorEd application for you to explore. However, as expected, certain features may be impaired without replacing the default environment variables with adopter-specific values. For example, variables related to notification email services and cloud file upload.
+The existing documentation and setup guides include a set of environment files with default environment variables. These serve as an excellent starting point for any deployment and offer a fully operational Mentor application for you to explore. 
 
-This document acts as a reference for such functionalities/features and their related environment variables.
+However, as expected, certain features may be impaired without replacing the default environment variables with adopter-specific values. For example, variables related to notification email services and cloud file upload.
+
+This document acts as a reference for such functionalities or features and their related environment variables.
 
 ## Affected Features
 
-1. **User SignUp**
+1. **User Signup**
 
-    Since an email with an OTP code is sent to verify the email ID provided during the signup process, the notification service environment variables must be configured with real values sourced from an email service. Currently, MentorEd's notification service natively supports Sendgrid as the default email service. Therefore, the following environment variables must be set for this feature to function properly.
+    Since an email with an OTP code is sent to verify the email ID provided during the signup process, the Notification service environment variables must be configured with real values sourced from an email service. 
+    
+    Currently, the Notification service natively supports [Twilio® SendGrid](https://sendgrid.com/en-us) as the default email service. Therefore, the following environment variables must be set for this feature to function properly.
 
     ### Notification Service
 
@@ -25,17 +29,13 @@ This document acts as a reference for such functionalities/features and their re
     SENDGRID_FROM_EMAIL
     ```
 
-    > **Note:** If the **APPLICATION_ENV** in the user service is set to "**development**," the OTP code will be logged in the console. This feature might be advantageous in a local setup as it bypasses the need for a Sendgrid account. Logging is disabled in production environments (**APPLICATION_ENV=production**).
-
-    ### Relevant Resources
-
-    1. [Twilio SendGrid](https://sendgrid.com/en-us)
+    > **Note:** If the **APPLICATION_ENV** in the User service is set to "**development**," the OTP code will be logged in the console. This feature might be advantageous in a local setup as it bypasses the need for a Sendgrid account. Logging is disabled in production environments (**APPLICATION_ENV=production**).
 
 2. **File Upload**
 
-    MentorEd utilises file upload functionality to implement several features like profile and session image upload, bulk user creation and bulk session creation. Therefore it is expected that you have a bucket configured with a cloud provider of your choosing (AWS, GCP, AZURE or OCI). And relevant environment fields are set in the following services.
+    The application utilizes file upload functionality to implement several features like profile and session image upload, bulk user creation and bulk session creation. Therefore, it is expected that you have a bucket configured with a cloud provider of your choosing (AWS, GCP, AZURE, or OCI). And relevant environment fields are set in the following services.
 
-    ### Mentoring & User Services
+    ### Mentor and User Services
 
     **Docker Setup:** `mentoring_env`, `user_env`
 
@@ -80,17 +80,17 @@ This document acts as a reference for such functionalities/features and their re
 
 3. **Support Emails**
 
-    MentorEd provides a mechanism for users to generate request emails that are sent to a support team overseeing user requests. For example, if a user wants to delete their account or report an issue, they can trigger an email with their request message from the portal.
+    The application provides a mechanism for users to generate request emails that are sent to a support team overseeing user requests. For example, if a user wants to delete their account or report an issue, they can trigger an email with their request message from the portal.
 
     <div style="text-align: left; width: 100%;">
-        <h4 style="text-align: left;">MentorEd Report Issue Help Page</h4>
+        <h4 style="text-align: left;">Report Issue Help Page</h4>
         <img src="../../public/images/help_report_issue.png" alt="MentorEd Report Issue Help Page" 
             style="max-width: 100%; height: auto; width: auto; max-height: 300px;">
     </div>
 
-    For this feature to function, support email IDs and other values must be set in the mentoring service as listed below.
+    For this feature to function, support email IDs and other values must be set in the Mentor service as listed below.
 
-    ### Mentoring Service
+    ### Mentor Service
 
     **Docker Setup:** `mentoring_env`
 
@@ -103,11 +103,11 @@ This document acts as a reference for such functionalities/features and their re
     ENABLE_EMAIL_FOR_REPORT_ISSUE			-> Already enabled in default/sample env files
     ```
 
-    > **IMPORTANT:** As a prerequisite, the notification service must be configured with the proper SendGrid environment variables, as shown in the User SignUp section.
+    > **Important:** As a prerequisite, the Notification service must be configured with the proper SendGrid environment variables, as shown in the User SignUp section.
 
 4. **Email Encryption**
 
-    Since version 2.6.1, MentorEd has enhanced its security by implementing system-wide email encryption, now enabled by default. This update ensures that email IDs are not stored as plaintext in the database. Instead, they are encrypted using the `AES-256-CBC` algorithm. The encryption and decryption processes are governed by the following environment variables:
+    Since version 2.6.1, the application has enhanced its security by implementing system-wide email encryption, now enabled by default. This update ensures that email IDs are not stored as plaintext in the database. Instead, they are encrypted using the `AES-256-CBC` algorithm. The encryption and decryption processes are governed by the following environment variables:
 
     ### User Service
 
@@ -122,15 +122,15 @@ This document acts as a reference for such functionalities/features and their re
     EMAIL_ID_ENCRYPTION_IV
     ```
 
-    > **CRITICAL:** The default environment files provided with the deployment guide contain default but valid values for the encryption variables mentioned above. It is crucial to replace these default values with unique ones for your deployment to ensure the security of your data. Failing to do so exposes you to the risk of using a publicly available KEY and IV pair for encrypting your email IDs.
+    > **Critical:** The default environment files provided with the deployment guide contain default but valid values for the email encryption variables. Replace these default values with unique ones for your deployment to avoid the risk of using a publicly available KEY and IV pair for encrypting your email IDs.
 
     To generate a new, valid pair of KEY and IV, you can use the following script: [Generate Encryption Keys](https://github.com/ELEVATE-Project/user/blob/master/src/scripts/generateEncyrptionKeys.js).
 
 5. **CAPTCHA**
 
-    Since version 2.6.1, MentorEd has introduced the option to implement CAPTCHA using [Google reCAPTCHA](https://www.google.com/recaptcha/about/) on various portal pages such as Login and SignUp. By default, this feature is disabled in the configuration settings found in the default environment files included in the deployment guide.
+    Since version 2.6.1, the application has introduced the option to implement CAPTCHA using [Google reCAPTCHA](https://www.google.com/recaptcha/about/) on various portal pages such as Login and SignUp. By default, this feature is disabled in the configuration settings found in the default environment files included in the deployment guide.
 
-    If you wish to enable CAPTCHA, you will need to obtain a `site key` and `secret key` from Google. To do this, follow the instructions provided in the [reCAPTCHA Developer Guide](https://developers.google.com/recaptcha/intro). Once you have your keys, update the following environment variables to activate CAPTCHA on your site.
+    If you wish to enable CAPTCHA, you need to obtain a `site key` and `secret key` from Google. To do this, follow the instructions provided in the [reCAPTCHA Developer Guide](https://developers.google.com/recaptcha/intro). Once you have your keys, update the following environment variables to activate CAPTCHA on your site.
 
     ### User Service
 
@@ -159,7 +159,7 @@ This document acts as a reference for such functionalities/features and their re
 
 6. **Session Management**
 
-    Since version 2.6.1, MentorEd has implemented advanced features for user session management, such as inactivity timeouts, session tracking, and remote logout. These features are controlled by the following environment variables:
+    Since version 2.6.1, the application includes advanced features for user session management, such as inactivity timeouts, session tracking, and remote logout. These features are controlled by the following environment variables:
 
     ### User Service
 
@@ -182,7 +182,7 @@ This document acts as a reference for such functionalities/features and their re
 
 7. **Rate Limiting**
 
-    Since version 2.6.1, Elevate has implemented rate-limiting to enhance system stability and prevent abuse. This feature regulates the number of requests a user can make to the services within a given timeframe. Rate-limiting is enabled by default.
+    The rate-limiting feature has been introduced in version 2.6.1 to enhance system stability and prevent abuse. This feature regulates the number of requests a user can make to the services within a given timeframe. Rate-limiting is enabled by default.
 
     ### User Service
 
@@ -197,4 +197,4 @@ This document acts as a reference for such functionalities/features and their re
     RATE_LIMITER_ENABLED
     ```
 
-    Refer to the [MentorEd Rate-Limiting Guide](./MentorEd-Rate-Limiting-Guide.md) for more information on how to set these variables.
+    Refer to the [Rate-Limiting Guide](./MentorEd-Rate-Limiting-Guide.md) for more information on how to set these variables.

--- a/documentation/latest/MentorEd-Rate-Limiting-Guide.md
+++ b/documentation/latest/MentorEd-Rate-Limiting-Guide.md
@@ -1,8 +1,8 @@
-# Developer Guide: Elevate Rate-Limiting Overview
+# Developer Guide: Rate-Limiting Overview
 
 ## Introduction
 
-Elevate Rate-Limiting aims to efficiently manage the flow of requests to our services and prevent misuse. It employs the express-rate-limit middleware and is primarily enforced at the interface service level, serving as the gateway to all our services. This guide provides detailed instructions and necessary configurations for integrating rate limiters in the development environment.
+Rate-Limiting aims to efficiently manage the flow of requests to our services and prevent misuse. It employs the express-rate-limit middleware and is primarily enforced at the interface service level, serving as the gateway to all our services. This guide provides detailed instructions and necessary configurations for integrating rate limiters in the development environment.
 
 ## Rate Limiting Strategy
 

--- a/documentation/latest/dockerized/MentorEd-Setup-README.md
+++ b/documentation/latest/dockerized/MentorEd-Setup-README.md
@@ -1,10 +1,16 @@
-## Dockerized Services & Dependencies
+## Dockerized Services and Dependencies
 
-Expectation: Upon following the prescribed steps, you will achieve a fully operational MentorEd application setup, complete with both the portal and backend services.
+Expectation: Upon following the prescribed steps, you will achieve a fully operational Mentor application setup, complete with both the portal and backend services.
 
 ## Prerequisites
 
-To set up the MentorEd application, ensure you have Docker and Docker Compose installed on your system. For Ubuntu users, detailed installation instructions for both can be found in the documentation here: [How To Install and Use Docker Compose on Ubuntu](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-compose-on-ubuntu-20-04). For Windows and MacOS users, you can refer to the Docker documentation for installation instructions: [Docker Compose Installation Guide](https://docs.docker.com/compose/install/). Once these prerequisites are in place, you're all set to get started with setting up the MentorEd application.
+To set up the application, you must install Docker and Docker Compose on your system using any one of the following ways:
+ 
+* Ubuntu users can refer to [How To Install and Use Docker Compose on Ubuntu](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-compose-on-ubuntu-20-04) for detailed installation instructions. 
+
+* Windows and MacOS users can refer to the [Docker Compose Installation Guide](https://docs.docker.com/compose/install/) for the installation instructions.
+
+Once these prerequisites are in place, you're all set to get started with setting up the application.
 
 ## Installation
 
@@ -18,7 +24,7 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
     curl -OJL https://github.com/ELEVATE-Project/mentoring/raw/master/documentation/2.6.1/dockerized/docker-compose-mentoring.yml
     ```
 
-    > Note: All commands are run from the mentoring directory.
+    > **Note:** Run all the commands from the mentoring directory.
 
     Directory structure:
 
@@ -53,9 +59,9 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
 
     > **Note:** Modify the environment files as necessary for your deployment using any text editor, ensuring that the values are appropriate for your environment. The default values provided in the current files are functional and serve as a good starting point. Refer to the sample env files provided at the [Mentoring](https://github.com/ELEVATE-Project/mentoring/blob/master/src/.env.sample), [User](https://github.com/ELEVATE-Project/user/blob/master/src/.env.sample), [Notification](https://github.com/ELEVATE-Project/notification/blob/master/src/.env.sample), [Scheduler](https://github.com/ELEVATE-Project/scheduler/blob/master/src/.env.sample), and [Interface](https://github.com/ELEVATE-Project/interface-service/blob/main/src/.env.sample) repositories for reference.
 
-    > **Caution:** While the default values in the downloaded environment files enable the MentorEd Application to operate, certain features may not function correctly or could be impaired unless the adopter-specific environment variables are properly configured.
+    > **Caution:** While the default values in the downloaded environment files enable the application to operate, certain features may not function correctly or could be impaired unless the adopter-specific environment variables are properly configured.
     >
-    > For detailed instructions on adjusting these values, please consult the **[MentorEd Environment Variable Modification Guide](https://github.com/ELEVATE-Project/mentoring/blob/master/documentation/2.6.1/MentorEd-Env-Modification-README.md)**.
+    > For detailed instructions on adjusting these values, please consult the **[Environment Variable Modification Guide](https://github.com/ELEVATE-Project/mentoring/blob/master/documentation/2.6.1/MentorEd-Env-Modification-README.md)**.
 
     > **Important:** As mentioned in the above linked document, the **User SignUp** functionality may be compromised if key environment variables are not set correctly during deployment. If you opt to skip this setup, consider using the sample user account generator detailed in the `Sample User Accounts Generation` section of this document.
 
@@ -98,7 +104,7 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
         >
         > \- /home/joffin/elevate/backend/environment.ts:/app/src/environments/environment.ts
 
-6.  **Download `docker-compose-up` & `docker-compose-down` Script Files**
+6.  **Download `docker-compose-up` and `docker-compose-down` Script Files**
 
     -   **Ubuntu/Linux/Mac**
 
@@ -132,7 +138,7 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
         curl -OJL https://github.com/ELEVATE-Project/mentoring/raw/master/documentation/2.6.1/dockerized/scripts/windows/docker-compose-down.bat
         ```
 
-7.  **Run All Services & Dependencies:** All services and dependencies can be started using the `docker-compose-up` script file.
+7.  **Run All Services and Dependencies:** All services and dependencies can be started using the `docker-compose-up` script file.
 
     -   **Ubuntu/Linux/Mac**
         ```
@@ -148,9 +154,9 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
 
         > **Note**: During the first Docker Compose run, the database, migration seeder files, and the script to set the default organization will be executed automatically.
 
-8.  **Access The MentorEd Application**: Once the services are up and the front-end app bundle is built successfully, navigate to **[localhost:8100](http://localhost:8100/)** to access the MentorEd app.
-9.  **Gracefully Stop All Services & Dependencies:** All containers which are part of the docker-compose can be gracefully stopped by pressing `Ctrl + c` in the same terminal where the services are running.
-10. **Remove All Service & Dependency Containers**: All docker containers can be stopped and removed by using the `docker-compose-down` file.
+8.  **Access The Application**: Once the services are up and the front-end app bundle is built successfully, navigate to **[localhost:8100](http://localhost:8100/)** to access the application.
+9.  **Gracefully Stop All Services and Dependencies:** All containers which are part of the docker-compose can be gracefully stopped by pressing `Ctrl + c` in the same terminal where the services are running.
+10. **Remove All Service and Dependency Containers**: All docker containers can be stopped and removed by using the `docker-compose-down` file.
 
     -   **Ubuntu/Linux/Mac**
         ```
@@ -166,11 +172,11 @@ To set up the MentorEd application, ensure you have Docker and Docker Compose in
 
 ## Enable Citus Extension
 
-MentorEd relies on PostgreSQL as its core database system. To boost performance and scalability, users can opt to enable the Citus extension. This transforms PostgreSQL into a distributed database, spreading data across multiple nodes to handle large datasets more efficiently as demand grows.
+The application relies on PostgreSQL as its core database system. To boost performance and scalability, users can opt to enable the Citus extension. This transforms PostgreSQL into a distributed database, spreading data across multiple nodes to handle large datasets more efficiently as demand grows.
 
 For more information, refer **[Citus Data](https://www.citusdata.com/)**.
 
-To enable the Citus extension for mentoring and user services, follow these steps.
+To enable the Citus extension for Mentor and User services, follow these steps.
 
 1. Create a sub-directory named `mentoring` and download `distributionColumns.sql` into it.
     ```
@@ -255,9 +261,9 @@ By implementing these adjustments, the configuration ensures that when the `dock
 
 ## Sample User Accounts Generation
 
-During the initial setup of MentorEd services with the default configuration, you may encounter issues creating new accounts through the regular SignUp flow on the MentorEd portal. This typically occurs because the default SignUp process includes OTP verification to prevent abuse. Until the notification service is configured correctly to send actual emails, you will not be able to create new accounts.
+During the initial setup of Mentor services with the default configuration, you may encounter issues creating new accounts through the regular Signup flow on the Mentor portal. This typically occurs because the default SignUp process includes OTP verification to prevent abuse. Until the notification service is configured correctly to send actual emails, you will not be able to create new accounts.
 
-In such cases, you can generate sample user accounts using the steps below. This allows you to explore the MentorEd services and portal immediately after setup.
+In such cases, you can generate sample user accounts using the steps below. This allows you to explore the services and portal immediately after setup.
 
 > **Warning:** Use this generator only immediately after the initial system setup and before any normal user accounts are created through the portal. It should not be used under any circumstances thereafter.
 

--- a/documentation/latest/native/MentorEd-Setup-README.md
+++ b/documentation/latest/native/MentorEd-Setup-README.md
@@ -1,10 +1,10 @@
 ## PM2 Managed Services & Natively Installed Dependencies
 
-Expectation: Upon following the prescribed steps, you will achieve a fully operational MentorEd application setup. Both the portal and backend services are managed using PM2, with all dependencies installed natively on the host system.
+Expectation: Upon following the prescribed steps, you will achieve a fully operational Mentor application setup. Both the portal and backend services are managed using PM2, with all dependencies installed natively on the host system.
 
 ## Prerequisites
 
-Before setting up the following MentorEd application, dependencies given below should be installed and verified to be running. Refer to the steps given below to install them and verify.
+Before setting up the application, the dependencies should be installed and verified to be running. Refer to the following steps to install them and verify:
 
 -   **Ubuntu/Linux**
 
@@ -111,7 +111,7 @@ Before setting up the following MentorEd application, dependencies given below s
 
         1. Adapt the instructions given in the following ["Apache Kafka on Windows"](https://www.conduktor.io/kafka/how-to-install-apache-kafka-on-windows/) documentation to install Kafka version 3.5.0.
 
-            > Note: As per the instructions, Kafka server and Zookeeper has to be kept active on different WSL terminals for the entire lifetime of MentorEd services.
+            > Note: As per the instructions, Kafka server and Zookeeper has to be kept active on different WSL terminals for the entire lifetime of Mentor services.
 
             > Note: Multiple WSL terminals can be opened by launching `Ubuntu` from start menu.
 
@@ -265,9 +265,9 @@ Before setting up the following MentorEd application, dependencies given below s
 
     > **Note:** Modify the environment files as necessary for your deployment using any text editor, ensuring that the values are appropriate for your environment. The default values provided in the current files are functional and serve as a good starting point. Refer to the sample env files provided at the [Mentoring](https://github.com/ELEVATE-Project/mentoring/blob/master/src/.env.sample), [User](https://github.com/ELEVATE-Project/user/blob/master/src/.env.sample), [Notification](https://github.com/ELEVATE-Project/notification/blob/master/src/.env.sample), [Scheduler](https://github.com/ELEVATE-Project/scheduler/blob/master/src/.env.sample), and [Interface](https://github.com/ELEVATE-Project/interface-service/blob/main/src/.env.sample) repositories for reference.
 
-    > **Caution:** While the default values in the downloaded environment files enable the MentorEd Application to operate, certain features may not function correctly or could be impaired unless the adopter-specific environment variables are properly configured.
+    > **Caution:** While the default values in the downloaded environment files enable the application to operate, certain features may not function correctly or could be impaired unless the adopter-specific environment variables are properly configured.
     >
-    > For detailed instructions on adjusting these values, please consult the **[MentorEd Environment Variable Modification Guide](https://github.com/ELEVATE-Project/mentoring/blob/master/documentation/2.6.1/MentorEd-Env-Modification-README.md)**.
+    > For detailed instructions on adjusting these values, please consult the **[Environment Variable Modification Guide](https://github.com/ELEVATE-Project/mentoring/blob/master/documentation/2.6.1/MentorEd-Env-Modification-README.md)**.
 
     > **Important:** As mentioned in the above linked document, the **User SignUp** functionality may be compromised if key environment variables are not set correctly during deployment. If you opt to skip this setup, consider using the sample user account generator detailed in the `Sample User Accounts Generation` section of this document.
 
@@ -341,9 +341,9 @@ Before setting up the following MentorEd application, dependencies given below s
 
 7. **Enabling Citus And Setting Distribution Columns (Optional)**
 
-    MentorEd relies on PostgreSQL as its core database system. To boost performance and scalability, users can opt to enable the Citus extension. This transforms PostgreSQL into a distributed database, spreading data across multiple nodes to handle large datasets more efficiently as demand grows.
+    The application relies on PostgreSQL as its core database system. To boost performance and scalability, users can opt to enable the Citus extension. This transforms PostgreSQL into a distributed database, spreading data across multiple nodes to handle large datasets more efficiently as demand grows.
 
-    > NOTE: Currently only available for Linux based operation systems.
+    > **Note:** Currently only available for Linux based operation systems.
 
     1. Download mentoring `distributionColumns.sql` file.
 
@@ -383,7 +383,7 @@ Before setting up the following MentorEd application, dependencies given below s
                 ```
 
 8. **Insert Initial Data**
-   Use MentorEd in-build seeders to insert the initial data.
+   Use the application's in-build seeders to insert the initial data.
 
     - **Ubuntu/Linux/MacOS**
 
@@ -400,7 +400,7 @@ Before setting up the following MentorEd application, dependencies given below s
 
 9. **Start The Services**
 
-    Following the steps given below, 2 instances of each MentorEd backend service will be deployed and be managed by PM2 process manager.
+    Following the steps given below, 2 instances of each Mentor backend service will be deployed and be managed by PM2 process manager.
 
     - **Ubuntu/Linux**
 
@@ -450,7 +450,7 @@ Before setting up the following MentorEd application, dependencies given below s
 
 11. **Start The Portal**
 
-    MentorEd portal utilizes Ionic and Angular CLI for building the browser bundle, follow the steps given below to install them and start the portal.
+    The portal utilizes Ionic and Angular CLI for building the browser bundle, follow the steps given below to install them and start the portal.
 
     - **Ubuntu/Linux**
 
@@ -545,13 +545,13 @@ Before setting up the following MentorEd application, dependencies given below s
             pm2 start pm2.config.json & cd ..
             ```
 
-    Navigate to http://localhost:7601 to access the MentorEd Portal.
+    Navigate to http://localhost:7601 to access the portal.
 
 ## Sample User Accounts Generation
 
-During the initial setup of MentorEd services with the default configuration, you may encounter issues creating new accounts through the regular SignUp flow on the MentorEd portal. This typically occurs because the default SignUp process includes OTP verification to prevent abuse. Until the notification service is configured correctly to send actual emails, you will not be able to create new accounts.
+During the initial setup of Mentor services with the default configuration, you may encounter issues creating new accounts through the regular Signup flow on the Mentor portal. This typically occurs because the default SignUp process includes OTP verification to prevent abuse. Until the notification service is configured correctly to send actual emails, you will not be able to create new accounts.
 
-In such cases, you can generate sample user accounts using the steps below. This allows you to explore the MentorEd services and portal immediately after setup.
+In such cases, you can generate sample user accounts using the steps below. This allows you to explore the services and portal immediately after setup.
 
 > **Warning:** Use this generator only immediately after the initial system setup and before any normal user accounts are created through the portal. It should not be used under any circumstances thereafter.
 


### PR DESCRIPTION
- Changed product and service name to Mentor as per an adopter-specific feedback received from the team.

- Added some editorial changes.