### PR TITLE
trigger email only for manager

### DIFF
--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -388,7 +388,7 @@ module.exports = class SessionsHelper {
 			}
 
 			let emailTemplateCode
-			if (bodyData.managerFlow && isSessionCreatedByManager && userDetails.email && notifyUser) {
+			if (bodyData.managerFlow && userDetails.email && notifyUser) {
 				if (data.type == common.SESSION_TYPE.PRIVATE) {
 					//assign template data
 					emailTemplateCode = process.env.MENTOR_PRIVATE_SESSION_INVITE_BY_MANAGER_EMAIL_TEMPLATE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mentor-invitation emails triggered by managers are now sent only when the manager flow is explicitly used, preventing unintended notifications and reducing stray emails. This improves control over who receives invitations and limits notifications to the intended workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->