### PR TITLE
update only meeting info on live

### DIFF
--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -736,17 +736,18 @@ module.exports = class SessionsHelper {
 					this.setMentorPassword(sessionId, bodyData.mentor_id)
 				}
 
-				if (sessionDetail.status == common.LIVE_STATUS && bodyData?.meeting_info) {
-					// Validate meeting_info structure before using it
-					if (!bodyData.meeting_info.platform || !bodyData.meeting_info.value) {
+				if (sessionDetail.status === common.LIVE_STATUS) {
+					const meetingInfo = bodyData?.meeting_info
+					if (!meetingInfo || !meetingInfo.platform || !meetingInfo.value) {
 						return responses.failureResponse({
 							message: 'INVALID_MEETING_INFO',
 							statusCode: httpStatusCode.bad_request,
 							responseCode: 'CLIENT_ERROR',
 						})
 					}
-					bodyData = { meeting_info: bodyData.meeting_info }
+					bodyData = { meeting_info: meetingInfo }
 				}
+
 				const { rowsAffected, updatedRows } = await sessionQueries.updateOne({ id: sessionId }, bodyData, {
 					returning: true,
 				})

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -736,10 +736,17 @@ module.exports = class SessionsHelper {
 					this.setMentorPassword(sessionId, bodyData.mentor_id)
 				}
 
-				if (sessionDetail.status == common.LIVE_STATUS && bodyData?.meetingInfo) {
-					bodyData = bodyData.meetingInfo
+				if (sessionDetail.status == common.LIVE_STATUS && bodyData?.meeting_info) {
+					// Validate meeting_info structure before using it
+					if (!bodyData.meeting_info.platform || !bodyData.meeting_info.value) {
+						return responses.failureResponse({
+							message: 'INVALID_MEETING_INFO',
+							statusCode: httpStatusCode.bad_request,
+							responseCode: 'CLIENT_ERROR',
+						})
+					}
+					bodyData = { meeting_info: bodyData.meeting_info }
 				}
-
 				const { rowsAffected, updatedRows } = await sessionQueries.updateOne({ id: sessionId }, bodyData, {
 					returning: true,
 				})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Allow updating meeting details (platform and value) during a live session, with validation and normalization.

- Bug Fixes
  - Prevent changes to mentee enrollment, resources, or mentor assignment while a session is live.
  - Reject live-session updates that include invalid or unauthorized changes beyond allowed meeting details; updates lacking valid meeting details are denied/ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->