### PR TITLE
Enroll ap ifix

### DIFF
--- a/src/database/queries/sessionAttendees.js
+++ b/src/database/queries/sessionAttendees.js
@@ -112,12 +112,32 @@ exports.findAll = async (filter, tenantCode, options = {}) => {
 
 exports.unEnrollAllAttendeesOfSessions = async (sessionIds, tenantCode) => {
 	try {
+		const recordsToDelete = await SessionAttendee.findAll({
+			where: {
+				session_id: { [Op.in]: sessionIds },
+				tenant_code: tenantCode,
+			},
+			raw: true, // optional, returns plain objects
+		})
+
+		// If nothing found
+		if (!recordsToDelete.length) {
+			return {
+				deletedCount: 0,
+				deletedRecords: [],
+			}
+		}
+
 		const destroyedCount = await SessionAttendee.destroy({
 			where: {
 				session_id: { [Op.in]: sessionIds },
 				tenant_code: tenantCode,
 			},
 		})
+		return {
+			deletedCount: destroyedCount,
+			deletedRecords: recordsToDelete,
+		}
 
 		return destroyedCount
 	} catch (error) {

--- a/src/database/queries/sessionAttendees.js
+++ b/src/database/queries/sessionAttendees.js
@@ -112,6 +112,9 @@ exports.findAll = async (filter, tenantCode, options = {}) => {
 
 exports.unEnrollAllAttendeesOfSessions = async (sessionIds, tenantCode) => {
 	try {
+		if (!tenantCode) {
+			throw new Error('tenantCode is required')
+		}
 		const recordsToDelete = await SessionAttendee.findAll({
 			where: {
 				session_id: { [Op.in]: sessionIds },

--- a/src/database/queries/sessionAttendees.js
+++ b/src/database/queries/sessionAttendees.js
@@ -138,8 +138,6 @@ exports.unEnrollAllAttendeesOfSessions = async (sessionIds, tenantCode) => {
 			deletedCount: destroyedCount,
 			deletedRecords: recordsToDelete,
 		}
-
-		return destroyedCount
 	} catch (error) {
 		return error
 	}

--- a/src/helpers/getEnrolledMentees.js
+++ b/src/helpers/getEnrolledMentees.js
@@ -36,7 +36,7 @@ exports.getEnrolledMentees = async (sessionId, queryParams, tenantCode) => {
 		})
 
 		// Fetch missing user details from DB if any
-		let userDetailsResult = await userRequests.getUserDetailedListUsingCache(menteesMapData, tenantCode)
+		let userDetailsResult = await userRequests.getUserDetailedListUsingCache(menteesMapData, tenantCode, true, true)
 		let enrolledUsers = userDetailsResult?.result || []
 
 		enrolledUsers.forEach((user) => {

--- a/src/requests/user.js
+++ b/src/requests/user.js
@@ -950,7 +950,7 @@ const getUserDetailedListUsingCache = async function (usersMap, tenantCode, dele
 				usersInfo.missingUserIds,
 				options,
 				tenantCode,
-				unscopped
+				(unscopped = true)
 			)
 			userDetails.push(...usersFromDb)
 		}

--- a/src/requests/user.js
+++ b/src/requests/user.js
@@ -950,7 +950,7 @@ const getUserDetailedListUsingCache = async function (usersMap, tenantCode, dele
 				usersInfo.missingUserIds,
 				options,
 				tenantCode,
-				(unscopped = true)
+				true
 			)
 			userDetails.push(...usersFromDb)
 		}

--- a/src/requests/user.js
+++ b/src/requests/user.js
@@ -950,7 +950,7 @@ const getUserDetailedListUsingCache = async function (usersMap, tenantCode, dele
 				usersInfo.missingUserIds,
 				options,
 				tenantCode,
-				true
+				unscopped
 			)
 			userDetails.push(...usersFromDb)
 		}

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -643,14 +643,16 @@ module.exports = class AdminService {
 			// Unenroll attendees from sessions
 			const sessionIds = removedSessionsDetail.map((session) => session.id)
 			const unenrollDetails = await sessionAttendeesQueries.unEnrollAllAttendeesOfSessions(sessionIds)
-			if (unenrollDetails.deletedCount > 0) {
-				const menteeIds = unenrollDetails.deletedRecords.map((item) => item.mentee_id)
-				for (const menteeId of menteeIds) {
+			if (unenrollDetails && unenrollDetails.deletedCount > 0 && Array.isArray(unenrollDetails.deletedRecords)) {
+				for (const menteeData of unenrollDetails.deletedRecords) {
 					try {
-						cacheHelper.mentee.delete(tenantCode, menteeId)
-					} catch (error) {}
+						await cacheHelper.mentee.delete(tenantCode, menteeData.organization_code, menteeData.mentee_id)
+					} catch (cacheError) {
+						console.error(`Cache deletion failed for mentee ${menteeId}:`, cacheError)
+					}
 				}
 			}
+
 			return notificationResult
 		} catch (error) {
 			console.error('An error occurred in notifySessionAttendees:', error)

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -642,7 +642,15 @@ module.exports = class AdminService {
 
 			// Unenroll attendees from sessions
 			const sessionIds = removedSessionsDetail.map((session) => session.id)
-			const unenrollCount = await sessionAttendeesQueries.unEnrollAllAttendeesOfSessions(sessionIds)
+			const unenrollDetails = await sessionAttendeesQueries.unEnrollAllAttendeesOfSessions(sessionIds)
+			if (unenrollDetails.deletedCount > 0) {
+				const menteeIds = unenrollDetails.deletedRecords.map((item) => item.mentee_id)
+				for (const menteeId of menteeIds) {
+					try {
+						cacheHelper.mentee.delete(tenantCode, menteeId)
+					} catch (error) {}
+				}
+			}
 			return notificationResult
 		} catch (error) {
 			console.error('An error occurred in notifySessionAttendees:', error)

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -642,7 +642,7 @@ module.exports = class AdminService {
 
 			// Unenroll attendees from sessions
 			const sessionIds = removedSessionsDetail.map((session) => session.id)
-			const unenrollDetails = await sessionAttendeesQueries.unEnrollAllAttendeesOfSessions(sessionIds)
+			const unenrollDetails = await sessionAttendeesQueries.unEnrollAllAttendeesOfSessions(sessionIds, tenantCode)
 			if (unenrollDetails && unenrollDetails.deletedCount > 0 && Array.isArray(unenrollDetails.deletedRecords)) {
 				for (const menteeData of unenrollDetails.deletedRecords) {
 					try {

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -134,6 +134,17 @@ module.exports = class OrgAdminService {
 				})
 			// Delete upcoming sessions of user as mentor
 			const removedSessionsDetail = await sessionQueries.removeAndReturnMentorSessions(bodyData.user_id)
+
+			if (removedSessionsDetail && removedSessionsDetail.length > 0) {
+				for (const userSession of removedSessionsDetail) {
+					try {
+						await cacheHelper.sessions.delete(tenantCode, userSession.id)
+					} catch (cacheError) {
+						console.error(`Cache deletion failed for session ${userSession.id}:`, cacheError)
+					}
+				}
+			}
+
 			const isAttendeesNotified = await adminService.unenrollAndNotifySessionAttendees(
 				removedSessionsDetail,
 				mentorDetails.organization_id ? mentorDetails.organization_id : '',

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -700,7 +700,7 @@ module.exports = class SessionsHelper {
 
 			// Use direct database query instead of cache
 			let mentorExtension =
-				(await cacheHelper.mentor.getCacheOnly(tenantCode, userId)) ??
+				(await cacheHelper.mentor.getCacheOnly(tenantCode, orgCode, userId)) ??
 				(await mentorExtensionQueries.getMentorExtension(userId, [], false, tenantCode))
 			if (!mentorExtension) {
 				return responses.failureResponse({
@@ -933,7 +933,7 @@ module.exports = class SessionsHelper {
 					await sessionQueries.addOwnership(sessionId, bodyData.mentor_id)
 					mentorUpdated = true
 					const newMentor =
-						(await cacheHelper.mentor.getCacheOnly(tenantCode, bodyData.mentor_id)) ??
+						(await cacheHelper.mentor.getCacheOnly(tenantCode, orgCode, bodyData.mentor_id)) ??
 						(await mentorExtensionQueries.getMentorExtension(bodyData.mentor_id, ['name'], true))
 					if (newMentor?.name) {
 						bodyData.mentor_name = newMentor.name
@@ -2136,9 +2136,9 @@ module.exports = class SessionsHelper {
 
 			if (mentorId || session.mentor_id) {
 				const mentorDetails =
-					(await cacheHelper.mentor.getCacheOnly(tenantCode, orgCode, session.mentor_id)) ??
+					(await cacheHelper.mentor.getCacheOnly(tenantCode, orgCode, mentorId || session.mentor_id)) ??
 					(await mentorExtensionQueries.getMentorExtension(
-						mentorId ? mentorId : session.mentor_id,
+						mentorId || session.mentor_id,
 						['name'],
 						true,
 						tenantCode
@@ -3567,7 +3567,7 @@ module.exports = class SessionsHelper {
 			const defaults = await getDefaults()
 
 			const userDetails =
-				(await cacheHelper.mentor.getCacheOnly(tenantCode, sessionDetail.mentor_id)) ??
+				(await cacheHelper.mentor.getCacheOnly(tenantCode, orgCode, sessionDetail.mentor_id)) ??
 				(await mentorExtensionQueries.getMentorExtension(
 					sessionDetail.mentor_id,
 					['name', 'email'],
@@ -4197,8 +4197,8 @@ module.exports = class SessionsHelper {
 
 				await adminService.unenrollAndNotifySessionAttendees(
 					removedSessionsDetail,
-					{ [Op.in]: [mentor.organization_code, defaults.orgCode] },
-					{ [Op.in]: [tenantCode, defaults.tenantCode] },
+					{ [Op.in]: [mentor.organization_code] },
+					{ [Op.in]: [tenantCode] },
 					tenantCode,
 					mentor.organization_code
 				)

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -58,10 +58,9 @@ module.exports = class SessionsHelper {
 	 * @param {String|Array} userIds - user ID(s) whose session counts changed
 	 * @param {String} tenantCode - tenant code
 	 * @param {String} orgCode - organization code
-	 * @param {String} action - action performed (create, enroll, unenroll, etc.)
 	 * @returns {Promise<void>}
 	 */
-	static async _clearUserCache(userIds, tenantCode, orgCode, action = 'session_change') {
+	static async _clearUserCache(userIds, tenantCode, orgCode) {
 		try {
 			// Ensure userIds is an array
 			const userIdArray = Array.isArray(userIds) ? userIds : [userIds]
@@ -849,12 +848,7 @@ module.exports = class SessionsHelper {
 					}
 
 					// Clear mentor cache since sessions_hosted count changed (session deleted)
-					await this._clearUserCacheForSessionCountChange(
-						sessionDetail.mentor_id,
-						tenantCode,
-						orgCode,
-						'session_delete'
-					)
+					await this._clearUserCache(sessionDetail.mentor_id, tenantCode, orgCode)
 
 					// Delete scheduled jobs associated with deleted session
 					for (let jobIndex = 0; jobIndex < sessionRelatedJobIds.length; jobIndex++) {
@@ -946,12 +940,7 @@ module.exports = class SessionsHelper {
 					}
 					this.setMentorPassword(sessionId, bodyData.mentor_id, tenantCode)
 
-					await this._clearUserCache(
-						[bodyData.mentor_id],
-						tenantCode,
-						sessionDetail.organization_code,
-						'mentor_change'
-					)
+					await this._clearUserCache([bodyData.mentor_id], tenantCode, sessionDetail.organization_code)
 				}
 
 				if (sessionDetail.status === common.LIVE_STATUS) {
@@ -2276,7 +2265,7 @@ module.exports = class SessionsHelper {
 			}
 
 			// Clear user cache since sessions_attended count changed
-			await this._clearUserCache(userId, tenantCode, orgCode, 'session_enroll')
+			await this._clearUserCache(userId, tenantCode, orgCode)
 
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
@@ -2420,7 +2409,7 @@ module.exports = class SessionsHelper {
 			}
 
 			// Clear user cache since sessions_attended count changed
-			await this._clearUserCache(userTokenData.user_id, tenantCode, orgCode, 'session_unenroll')
+			await this._clearUserCache(userTokenData.user_id, tenantCode, orgCode)
 
 			return responses.successResponse({
 				statusCode: httpStatusCode.accepted,
@@ -3763,7 +3752,7 @@ module.exports = class SessionsHelper {
 
 			// Clear user caches for all successfully removed mentees since sessions_attended count changed
 			if (successIds.length > 0) {
-				await this._clearUserCache(successIds, tenantCode, orgCode, 'bulk_mentee_removal')
+				await this._clearUserCache(successIds, tenantCode, orgCode)
 			}
 
 			return responses.successResponse({
@@ -4182,12 +4171,7 @@ module.exports = class SessionsHelper {
 					mentor.organization_code
 				)
 
-				await this._clearUserCache(
-					[mentor.user_id],
-					tenantCode,
-					mentor.organization_code,
-					'remove_sessions_by_mentor'
-				)
+				await this._clearUserCache([mentor.user_id], tenantCode, mentor.organization_code)
 				return mentorId
 			})
 		)
@@ -4226,12 +4210,7 @@ module.exports = class SessionsHelper {
 					mentor.organization_code
 				)
 
-				await this._clearUserCache(
-					[mentor.user_id],
-					tenantCode,
-					mentor.organization_code,
-					'remove_sessions_by_org'
-				)
+				await this._clearUserCache([mentor.user_id], tenantCode, mentor.organization_code)
 				return mentor.user_id
 			})
 		)

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -3451,10 +3451,12 @@ module.exports = class SessionsHelper {
 		sessionDetails = null
 	) {
 		try {
+			if (!sessionDetails) {
+				sessionDetails =
+					(await cacheHelper.sessions.get(tenantCode, sessionId)) ??
+					(await sessionQueries.findById(sessionId, tenantCode))
+			}
 			// Check if session exists - use database query instead of cache for reliability
-			const sessionDetails =
-				(await cacheHelper.sessions.get(tenantCode, sessionId)) ??
-				(await sessionQueries.findById(sessionId, tenantCode))
 			if (!sessionDetails) {
 				return responses.failureResponse({
 					message: 'SESSION_NOT_FOUND',

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1621,7 +1621,11 @@ module.exports = class SessionsHelper {
 					})
 				}
 
-				if (!validateDefaultRules && userId != sessionDetails.mentor_id) {
+				if (
+					!validateDefaultRules &&
+					userId != sessionDetails.mentor_id &&
+					userId != sessionDetails.created_by
+				) {
 					return responses.failureResponse({
 						message: 'SESSION_NOT_FOUND',
 						statusCode: httpStatusCode.bad_request,

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -3494,7 +3494,7 @@ module.exports = class SessionsHelper {
 			// Enroll mentees
 			const successIds = []
 			const failedIds = []
-			const effectiveMentorId = mentorId ? mentorId : sessionData.mentor_id
+			const effectiveMentorId = mentorId ? mentorId : sessionDetails.mentor_id
 
 			const enrollPromises = mentees.map((menteeData) =>
 				this.enroll(
@@ -3503,7 +3503,7 @@ module.exports = class SessionsHelper {
 					timeZone,
 					menteeData.is_mentor,
 					false,
-					sessionData,
+					sessionDetails,
 					effectiveMentorId, // mentorId
 					organizationCode,
 					tenantCode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

### Key Changes

- **Cache Invalidation for Mentor Transitions**: Added cache cleanup when mentors transition to mentees, with defensive error handling for failed cache deletions
- **API Refactoring**: Renamed `_clearUserCacheForSessionCountChange()` to `_clearUserCache()` with simplified parameters (removed action parameter) and updated all call sites accordingly
- **Cache-First Architecture**: Expanded cache-first retrieval patterns across mentor/mentee/session/resource lookups; replaced direct database queries with `cacheHelper.getCacheOnly()` and `getCacheThenFallback()` patterns throughout session lifecycle
- **Resilient Cache Operations**: Wrapped all cache invalidations and lookups in try/catch blocks to ensure business logic continues gracefully on cache failures
- **Resource URL Handling**: Introduced `getResourceAccessibleUrl()` public method to normalize and standardize resource links into accessible URLs during session creation, details, and completion
- **Session Lifecycle Optimization**: Updated session operations (enroll, unenroll, update, delete, start, share) to perform intelligent cache operations with automatic database fallbacks
- **Enrollment Data Access Simplification**: Simplified `getEnrolledMentees()` signature by removing unused `userID` parameter, reducing API surface complexity
- **Attendee Unenrollment Enhancement**: Modified `unEnrollAllAttendeesOfSessions()` to return structured object containing both `deletedCount` and `deletedRecords`, enabling granular per-attendee cache invalidation
- **Per-Record Cache Cleanup**: Added targeted mentee cache invalidation during session unenrollment, iterating through deleted records to clear individual mentee cache entries
- **Data Sourcing Optimization**: Mentor and mentee metadata (names, emails) now preferentially sourced from cache with seamless database fallbacks for resilience

### Contribution Summary

| Author | Lines Added | Lines Removed |
|--------|------------|---------------|
| Rocky (rakeshSgr) | 10,055 | 0 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->