### PR TITLE
refactor(connection): add tenant code parameter to service layer

### DIFF
--- a/src/controllers/v1/connections.js
+++ b/src/controllers/v1/connections.js
@@ -147,7 +147,7 @@ module.exports = class Connection {
 	 */
 	async checkConnection(req) {
 		try {
-			return await connectionsService.checkConnectionIfExists(req.decodedToken.id, req.body)
+			return await connectionsService.checkConnectionIfExists(req.decodedToken.id, req.body, req.tenant_code)
 		} catch (error) {
 			throw error
 		}

--- a/src/controllers/v1/connections.js
+++ b/src/controllers/v1/connections.js
@@ -147,7 +147,11 @@ module.exports = class Connection {
 	 */
 	async checkConnection(req) {
 		try {
-			return await connectionsService.checkConnectionIfExists(req.decodedToken.id, req.body, req.tenant_code)
+			return await connectionsService.checkConnectionIfExists(
+				req.decodedToken.id,
+				req.body,
+				req.decodedToken.tenant_code
+			)
 		} catch (error) {
 			throw error
 		}

--- a/src/services/connections.js
+++ b/src/services/connections.js
@@ -687,7 +687,7 @@ module.exports = class ConnectionHelper {
 	 * @returns {Promise<Object>} A success response indicating whether the connection exists.
 	 * @throws Will throw an error if an unexpected issue occurs during the check.
 	 */
-	static async checkConnectionIfExists(user_id, body) {
+	static async checkConnectionIfExists(user_id, body, tenantCode) {
 		try {
 			const { friend_id } = body
 
@@ -700,7 +700,7 @@ module.exports = class ConnectionHelper {
 				})
 			}
 
-			const userInfo = await communicationHelper.resolve(friend_id)
+			const userInfo = await communicationHelper.resolve(friend_id, tenantCode)
 			if (!userInfo) {
 				return responses.failureResponse({
 					responseCode: 'CLIENT_ERROR',
@@ -709,7 +709,7 @@ module.exports = class ConnectionHelper {
 				})
 			}
 
-			const connectionCheck = await connectionQueries.getConnection(user_id, userInfo.user_id)
+			const connectionCheck = await connectionQueries.getConnection(user_id, userInfo.user_id, tenantCode)
 
 			if (connectionCheck) {
 				connectionExists = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added missing `tenantCode` parameter to the connections API `checkConnection` flow to ensure proper tenant isolation.
- Extended `checkConnectionIfExists()` in the connections service to accept `tenantCode` and propagate it to dependent calls (`communicationHelper.resolve()` and `connectionQueries.getConnection()`).
- Updated connections controller to pass `req.tenant_code` to the service layer for multi-tenant support.
- Adjusted service return payload to include message 'CONNECTED_STATUS_FETCHED' with result { data: { connection: boolean } } and added explicit error logging in the catch block.

| Author | Lines Added | Lines Removed |
|--------|-------------:|--------------:|
| sumanvpacewisdom | 883 | 0 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->