### PR TITLE
feat(connection): propagate tenant_code through service call chain

### DIFF
--- a/src/controllers/v1/connections.js
+++ b/src/controllers/v1/connections.js
@@ -147,7 +147,7 @@ module.exports = class Connection {
 	 */
 	async checkConnection(req) {
 		try {
-			return await connectionsService.checkConnectionIfExists(req.decodedToken.id, req.body)
+			return await connectionsService.checkConnectionIfExists(req.decodedToken.id, req.body, req.tenant_code)
 		} catch (error) {
 			throw error
 		}

--- a/src/controllers/v1/connections.js
+++ b/src/controllers/v1/connections.js
@@ -147,7 +147,11 @@ module.exports = class Connection {
 	 */
 	async checkConnection(req) {
 		try {
-			return await connectionsService.checkConnectionIfExists(req.decodedToken.id, req.body, req.tenant_code)
+			return await connectionsService.checkConnectionIfExists(
+				req.decodedToken.id,
+				req.body,
+				req.decodedToken.tenant_code
+			)
 		} catch (error) {
 			throw error
 		}

--- a/src/services/connections.js
+++ b/src/services/connections.js
@@ -687,7 +687,7 @@ module.exports = class ConnectionHelper {
 	 * @returns {Promise<Object>} A success response indicating whether the connection exists.
 	 * @throws Will throw an error if an unexpected issue occurs during the check.
 	 */
-	static async checkConnectionIfExists(user_id, body) {
+	static async checkConnectionIfExists(user_id, body, tenantCode) {
 		try {
 			const { friend_id } = body
 
@@ -700,7 +700,7 @@ module.exports = class ConnectionHelper {
 				})
 			}
 
-			const userInfo = await communicationHelper.resolve(friend_id)
+			const userInfo = await communicationHelper.resolve(friend_id, tenantCode)
 			if (!userInfo) {
 				return responses.failureResponse({
 					responseCode: 'CLIENT_ERROR',
@@ -709,7 +709,7 @@ module.exports = class ConnectionHelper {
 				})
 			}
 
-			const connectionCheck = await connectionQueries.getConnection(user_id, userInfo.user_id)
+			const connectionCheck = await connectionQueries.getConnection(user_id, userInfo.user_id, tenantCode)
 
 			if (connectionCheck) {
 				connectionExists = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Add tenant code parameter to checkConnection API**: The `checkConnection` method in the controller now passes the `tenant_code` from the decoded authentication token to the service layer
- **Extend checkConnectionIfExists method signature**: Updated the `checkConnectionIfExists` method to accept a third parameter (`tenantCode`) in addition to `user_id` and `body`
- **Implement tenant-aware connection lookups**: Connection existence checks now include `tenantCode` when querying the database via `connectionQueries.getConnection`
- **Improve tenant isolation**: Enhanced multi-tenant support by ensuring connection queries are scoped to the appropriate tenant context

## Contribution Summary

| Author | Email | Lines Added | Lines Removed |
|--------|-------|-------------|---------------|
| Nevil | nevil@tunerlabs.com | 887 | 0 |
| Rocky | 49852443+rakeshSgr@users.noreply.github.com | 763 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->