### PR TITLE
Mentee List API Designation and policy issue

### DIFF
--- a/src/database/queries/sessions.js
+++ b/src/database/queries/sessions.js
@@ -902,7 +902,7 @@ exports.getMentorsUpcomingSessionsFromView = async (
 		FROM
 				${utils.getTenantViewName(tenantCode, Session.tableName)} as Sessions
 				LEFT JOIN session_attendees AS sa
-				ON Sessions.id = sa.session_id AND sa.tenant_code = :tenantCode
+				ON Sessions.id = sa.session_id AND sa.mentee_id = :menteeUserId AND sa.tenant_code = :tenantCode
 		WHERE
 			mentor_id = :mentorId
 				AND status = 'PUBLISHED'
@@ -948,7 +948,7 @@ exports.getMentorsUpcomingSessionsFromView = async (
 		FROM
 		${utils.getTenantViewName(tenantCode, Session.tableName)} as Sessions
 		LEFT JOIN session_attendees AS sa
-				ON Sessions.id = sa.session_id AND sa.tenant_code = :tenantCode
+				ON Sessions.id = sa.session_id AND sa.mentee_id = :menteeUserId  AND sa.tenant_code = :tenantCode
 		WHERE
 			mentor_id = :mentorId
 				AND status = 'PUBLISHED'

--- a/src/database/queries/sessions.js
+++ b/src/database/queries/sessions.js
@@ -902,7 +902,7 @@ exports.getMentorsUpcomingSessionsFromView = async (
 		FROM
 				${utils.getTenantViewName(tenantCode, Session.tableName)} as Sessions
 				LEFT JOIN session_attendees AS sa
-				ON Sessions.id = sa.session_id AND sa.mentee_id = :menteeUserId AND sa.tenant_code = :tenantCode
+				ON Sessions.id = sa.session_id AND sa.tenant_code = :tenantCode
 		WHERE
 			mentor_id = :mentorId
 				AND status = 'PUBLISHED'
@@ -948,7 +948,7 @@ exports.getMentorsUpcomingSessionsFromView = async (
 		FROM
 		${utils.getTenantViewName(tenantCode, Session.tableName)} as Sessions
 		LEFT JOIN session_attendees AS sa
-				ON Sessions.id = sa.session_id AND sa.mentee_id = :menteeUserId  AND sa.tenant_code = :tenantCode
+				ON Sessions.id = sa.session_id AND sa.tenant_code = :tenantCode
 		WHERE
 			mentor_id = :mentorId
 				AND status = 'PUBLISHED'

--- a/src/services/mentees.js
+++ b/src/services/mentees.js
@@ -1492,15 +1492,17 @@ module.exports = class MenteesHelper {
 				additionalProjectionString = queryParams.fields
 				delete queryParams.fields
 			}
-			let organization_ids = []
 
+			// Parse organization codes from query parameters
+			let organization_codes = []
+			if (queryParams.hasOwnProperty('organization_codes')) {
+				organization_codes = queryParams['organization_codes'].split(',')
+			}
+
+			// Extract sort parameters
 			const [sortBy, order] = ['name'].includes(queryParams.sort_by)
 				? [queryParams.sort_by, queryParams.order || 'ASC']
 				: [false, 'ASC']
-
-			if (queryParams.hasOwnProperty('organization_ids')) {
-				organization_ids = queryParams['organization_ids'].split(',')
-			}
 
 			const query = utils.processQueryParametersWithExclusions(queryParams)
 			const userExtensionModelName = await menteeQueries.getModelName()
@@ -1518,7 +1520,7 @@ module.exports = class MenteesHelper {
 					connectedQuery,
 					searchText,
 					queryParams.mentorId ? queryParams.mentorId : userId,
-					organization_ids,
+					organization_codes,
 					[], // roles can be passed if needed
 					tenantCode
 				)
@@ -1566,11 +1568,7 @@ module.exports = class MenteesHelper {
 				userExtensionModelName
 			)
 
-			let filteredQuery = utils.validateAndBuildFilters(
-				query,
-				JSON.parse(JSON.stringify(validationData)),
-				userExtensionModelName
-			)
+			let filteredQuery = utils.validateAndBuildFilters(query, validationData)
 
 			const emailIds = []
 			const searchTextArray = searchText ? searchText.split(',') : []
@@ -1585,7 +1583,7 @@ module.exports = class MenteesHelper {
 			const saasFilter = await this.filterMenteeListBasedOnSaasPolicy(
 				userId,
 				isAMentor,
-				organization_ids,
+				organization_codes,
 				tenantCode,
 				organizationCode
 			)
@@ -1633,18 +1631,15 @@ module.exports = class MenteesHelper {
 			extensionDetails.data = await Promise.all(
 				extensionDetails.data.map(async (user) => {
 					let decryptedEmail = null
-					// Safely decrypt email with error handling
 					if (user.email) {
 						try {
 							decryptedEmail = await emailEncryption.decrypt(user.email)
 						} catch (decryptError) {
-							// Keep original email or set to null if decryption fails
 							decryptedEmail = null
 						}
 					}
 
 					let imageUrl = null
-					// Safely get downloadable URL for image with error handling
 					if (user.image) {
 						try {
 							imageUrl = (await utils.getDownloadableUrl(user.image)) ?? null
@@ -1667,21 +1662,20 @@ module.exports = class MenteesHelper {
 			// Step 5: Process entity types (reuse organizationIds) with error handling
 			if (extensionDetails.data.length > 0) {
 				try {
+					const organizationCodes = uniqueOrgs.map((org) => org.organization_code).filter(Boolean)
 					const processedData = await entityTypeService.processEntityTypesToAddValueLabels(
 						extensionDetails.data,
-						organizationIds,
+						organizationCodes,
 						userExtensionModelName,
-						'organization_id',
+						'organization_code',
 						[],
-						[tenantCode] // Pass tenantCode to the entity processing service
+						[tenantCode]
 					)
 					if (Array.isArray(processedData)) {
 						extensionDetails.data = processedData
-					} else {
-						// Keep original data if processing fails
 					}
 				} catch (entityError) {
-					// Keep original data if processing fails
+					return entityError
 				}
 			}
 
@@ -1720,7 +1714,7 @@ module.exports = class MenteesHelper {
 			throw error
 		}
 	}
-	static async filterMenteeListBasedOnSaasPolicy(userId, isAMentor, organization_ids = [], tenantCode, orgCode) {
+	static async filterMenteeListBasedOnSaasPolicy(userId, isAMentor, organizationKeys = [], tenantCode, orgCode) {
 		try {
 			// let extensionColumns = isAMentor ? await mentorQueries.getColumns() : await menteeQueries.getColumns()
 			// // check for external_mentee_visibility else fetch external_mentor_visibility
@@ -1732,13 +1726,13 @@ module.exports = class MenteesHelper {
 			const userPolicyDetails = isAMentor
 				? await mentorQueries.getMentorExtension(
 						userId,
-						['external_mentee_visibility', 'organization_id'],
+						['external_mentee_visibility', 'organization_id', 'organization_code'],
 						false,
 						tenantCode
 				  )
 				: await menteeQueries.getMenteeExtension(
 						userId,
-						['external_mentee_visibility', 'organization_id'],
+						['external_mentee_visibility', 'organization_id', 'organization_code'],
 						false,
 						tenantCode
 				  )
@@ -1784,41 +1778,36 @@ module.exports = class MenteesHelper {
 			}
 
 			let filter = ''
-			// searching for specific organization
-			let additionalFilter = ``
-			if (organization_ids.length !== 0) {
-				additionalFilter = `AND "organization_id" in (${organization_ids.map((id) => `'${id}'`).join(',')}) `
+			let additionalFilter = ''
+
+			if (organizationKeys.length !== 0) {
+				additionalFilter = `AND "organization_code" in (${organizationKeys
+					.map((code) => `'${code}'`)
+					.join(',')}) `
 			}
-			if (getOrgPolicy.external_mentee_visibility_policy && userPolicyDetails.organization_id) {
+			const requesterOrgCode = userPolicyDetails.organization_code || getOrgPolicy?.organization_code || orgCode
+			const requesterOrgId = userPolicyDetails.organization_id
+
+			// Important: visible_to_organizations stores organization IDs (from related_orgs), not codes
+			// So we must use organization_id when checking visible_to_organizations
+			if (getOrgPolicy?.external_mentee_visibility_policy && requesterOrgCode && requesterOrgId) {
 				const visibilityPolicy = getOrgPolicy.external_mentee_visibility_policy
 
 				// Filter user data based on policy
 				// generate filter based on condition
 				if (visibilityPolicy === common.CURRENT) {
-					/**
-					 * if user external_mentor_visibility is current. He can only see his/her organizations mentors
-					 * so we will check mentor's organization_id and user organization_id are matching
-					 */
-					filter = `AND "organization_id" = '${userPolicyDetails.organization_id}'`
+					filter = `AND "organization_code" = '${requesterOrgCode}'`
 				} else if (visibilityPolicy === common.ASSOCIATED) {
-					/**
-					 * If user external_mentor_visibility is associated
-					 * <<point**>> first we need to check if mentor's visible_to_organizations contain the user organization_id and verify mentor's visibility is not current (if it is ALL and ASSOCIATED it is accessible)
-					 */
 					filter =
 						additionalFilter +
-						`AND ( (:userOrgId = ANY("visible_to_organizations") AND "mentee_visibility" != 'CURRENT')`
+						`AND ( ('${requesterOrgId}' = ANY("visible_to_organizations") AND "mentee_visibility" != 'CURRENT')`
 
-					if (additionalFilter.length === 0) filter += ` OR organization_id = :userOrgId )`
+					if (additionalFilter.length === 0) filter += ` OR organization_code = '${requesterOrgCode}' )`
 					else filter += `)`
 				} else if (visibilityPolicy === common.ALL) {
-					/**
-					 * We need to check if mentor's visible_to_organizations contain the user organization_id and verify mentor's visibility is not current (if it is ALL and ASSOCIATED it is accessible)
-					 * OR if mentor visibility is ALL that mentor is also accessible
-					 */
 					filter =
 						additionalFilter +
-						`AND (('${userPolicyDetails.organization_id}' = ANY("visible_to_organizations") AND "mentee_visibility" != 'CURRENT' ) OR "mentee_visibility" = 'ALL' OR "organization_id" = '${userPolicyDetails.organization_id}')`
+						`AND (('${requesterOrgId}' = ANY("visible_to_organizations") AND "mentee_visibility" != 'CURRENT' ) OR "mentee_visibility" = 'ALL' OR "organization_code" = '${requesterOrgCode}')`
 				}
 			}
 

--- a/src/services/mentees.js
+++ b/src/services/mentees.js
@@ -1495,8 +1495,8 @@ module.exports = class MenteesHelper {
 
 			// Parse organization codes from query parameters
 			let organization_codes = []
-			if (queryParams.hasOwnProperty('organization_codes')) {
-				organization_codes = queryParams['organization_codes'].split(',')
+			if (queryParams.hasOwnProperty('organization_ids')) {
+				organization_codes = queryParams['organization_ids'].split(',')
 			}
 
 			// Extract sort parameters
@@ -1675,7 +1675,8 @@ module.exports = class MenteesHelper {
 						extensionDetails.data = processedData
 					}
 				} catch (entityError) {
-					return entityError
+					console.error('Error processing entity types:', entityError)
+					throw entityError
 				}
 			}
 
@@ -1714,7 +1715,7 @@ module.exports = class MenteesHelper {
 			throw error
 		}
 	}
-	static async filterMenteeListBasedOnSaasPolicy(userId, isAMentor, organizationKeys = [], tenantCode, orgCode) {
+	static async filterMenteeListBasedOnSaasPolicy(userId, isAMentor, organizationCodes = [], tenantCode, orgCode) {
 		try {
 			// let extensionColumns = isAMentor ? await mentorQueries.getColumns() : await menteeQueries.getColumns()
 			// // check for external_mentee_visibility else fetch external_mentor_visibility
@@ -1780,12 +1781,12 @@ module.exports = class MenteesHelper {
 			let filter = ''
 			let additionalFilter = ''
 
-			if (organizationKeys.length !== 0) {
-				additionalFilter = `AND "organization_code" in (${organizationKeys
+			if (organizationCodes.length !== 0) {
+				additionalFilter = `AND "organization_code" in (${organizationCodes
 					.map((code) => `'${code}'`)
 					.join(',')}) `
 			}
-			const requesterOrgCode = userPolicyDetails.organization_code || getOrgPolicy?.organization_code || orgCode
+			const requesterOrgCode = userPolicyDetails.organization_code
 			const requesterOrgId = userPolicyDetails.organization_id
 
 			// Important: visible_to_organizations stores organization IDs (from related_orgs), not codes
@@ -1796,8 +1797,16 @@ module.exports = class MenteesHelper {
 				// Filter user data based on policy
 				// generate filter based on condition
 				if (visibilityPolicy === common.CURRENT) {
+					/**
+					 * if user external_mentor_visibility is current. He can only see his/her organizations mentors
+					 * so we will check mentor's organization_id and user organization_id are matching
+					 */
 					filter = `AND "organization_code" = '${requesterOrgCode}'`
 				} else if (visibilityPolicy === common.ASSOCIATED) {
+					/**
+					 * If user external_mentor_visibility is associated
+					 * <<point**>> first we need to check if mentor's visible_to_organizations contain the user organization_id and verify mentor's visibility is not current (if it is ALL and ASSOCIATED it is accessible)
+					 */
 					filter =
 						additionalFilter +
 						`AND ( ('${requesterOrgId}' = ANY("visible_to_organizations") AND "mentee_visibility" != 'CURRENT')`
@@ -1805,6 +1814,10 @@ module.exports = class MenteesHelper {
 					if (additionalFilter.length === 0) filter += ` OR organization_code = '${requesterOrgCode}' )`
 					else filter += `)`
 				} else if (visibilityPolicy === common.ALL) {
+					/**
+					 * We need to check if mentor's visible_to_organizations contain the user organization_id and verify mentor's visibility is not current (if it is ALL and ASSOCIATED it is accessible)
+					 * OR if mentor visibility is ALL that mentor is also accessible
+					 */
 					filter =
 						additionalFilter +
 						`AND (('${requesterOrgId}' = ANY("visible_to_organizations") AND "mentee_visibility" != 'CURRENT' ) OR "mentee_visibility" = 'ALL' OR "organization_code" = '${requesterOrgCode}')`

--- a/src/services/mentors.js
+++ b/src/services/mentors.js
@@ -1278,7 +1278,7 @@ module.exports = class MentorsHelper {
 				if (queryParams.hasOwnProperty(key) & ((key === 'email') | (key === 'name'))) {
 					userServiceQueries[key] = queryParams[key]
 				}
-				if (queryParams.hasOwnProperty(key) & (key === 'organization_codes')) {
+				if (queryParams.hasOwnProperty(key) & (key === 'organization_ids')) {
 					organization_codes = queryParams[key].split(',')
 				}
 


### PR DESCRIPTION
- Updated session queries to remove mentee_id from join conditions.
- Changed organization_ids to organization_codes for better clarity and consistency.
- Enhanced filtering logic to use organization codes instead of IDs in various query parameters.
- Improved error handling and comments for better maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

### Key Changes
- Updated mentee list API to improve organization handling and filtering logic
- Modified session queries to include mentee_id in join conditions for accurate session retrieval
- Enhanced error handling in MenteesHelper with improved logging and error propagation
- Improved organization visibility checks based on user policies in mentee and mentor services
- Updated `filterMenteeListBasedOnSaasPolicy()` method signature to use organization codes parameter
- Standardized organization parameter handling across mentee and mentor service queries

### Contributor Statistics

| Author | File | Lines Added | Lines Removed |
|--------|------|-------------|---------------|
| sumanvpacewisdom | src/services/mentees.js | 35 | 33 |
| sumanvpacewisdom | src/services/mentors.js | 1 | 1 |
| **Total** | | **36** | **34** |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->