### PR TITLE
Refactor getSessionTenantCode method to remove tenantCode parameter a…

### DIFF
--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -2725,9 +2725,11 @@ module.exports = class SessionsHelper {
 	 * @param {String} sessionId - session id.
 	 * @returns {Object} - session data with tenant_code.
 	 */
-	static async getSessionTenantCode(sessionId, tenantCode) {
+	static async getSessionTenantCode(sessionId) {
 		try {
-			return await sessionQueries.findSessionForPublicEndpoint(sessionId, tenantCode)
+			// Use specialized query that does NOT require tenant_code.
+			// This is critical for BBB callbacks which do not send auth tokens or tenantCode.
+			return await sessionQueries.getSessionTenantCode(sessionId)
 		} catch (error) {
 			throw error
 		}


### PR DESCRIPTION
…nd use specialized query for BBB callbacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Refactored `getSessionTenantCode` method in `SessionsHelper` to remove the `tenantCode` parameter
- Updated method to use a specialized query (`sessionQueries.getSessionTenantCode(sessionId)`) instead of `sessionQueries.findSessionForPublicEndpoint(sessionId, tenantCode)`
- Added inline comments clarifying that the new query does not require tenantCode and is needed for BigBlueButton callbacks that lack auth tokens

## Changes by Author

| Author | File | Lines Added | Lines Removed |
|--------|------|-------------|---------------|
| sumanvpacewisdom | src/services/sessions.js | 4 | 2 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->