### PR TITLE
Fix for Desigantion in mentee and mentor list

### DIFF
--- a/src/helpers/entityTypeCache.js
+++ b/src/helpers/entityTypeCache.js
@@ -282,9 +282,9 @@ async function getEntityTypesAndEntitiesForModel(modelName, tenantCode, orgCode,
 			const userFilter = {
 				status: 'ACTIVE',
 				organization_code: orgCode,
-				model_names: { [Op.contains]: modelName },
+				model_names: { [Op.contains]: [modelName] },
 			}
-			const userEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, tenantCode)
+			const userEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, [tenantCode])
 			if (userEntityTypes && userEntityTypes.length > 0) {
 				allEntityTypes.push(...userEntityTypes)
 			}
@@ -300,10 +300,9 @@ async function getEntityTypesAndEntitiesForModel(modelName, tenantCode, orgCode,
 					organization_code: defaults.orgCode,
 					model_names: { [Op.contains]: [modelName] },
 				}
-				const defaultEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(
-					defaultFilter,
-					defaults.tenantCode
-				)
+				const defaultEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(defaultFilter, [
+					defaults.tenantCode,
+				])
 				if (defaultEntityTypes && defaultEntityTypes.length > 0) {
 					// Merge defaults, avoiding duplicates by ID
 					const existingIds = new Set(allEntityTypes.map((et) => et.id))

--- a/src/helpers/entityTypeCache.js
+++ b/src/helpers/entityTypeCache.js
@@ -284,7 +284,7 @@ async function getEntityTypesAndEntitiesForModel(modelName, tenantCode, orgCode,
 				organization_code: orgCode,
 				model_names: { [Op.contains]: [modelName] },
 			}
-			const userEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, [tenantCode])
+			const userEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, tenantCode)
 			if (userEntityTypes && userEntityTypes.length > 0) {
 				allEntityTypes.push(...userEntityTypes)
 			}
@@ -300,9 +300,10 @@ async function getEntityTypesAndEntitiesForModel(modelName, tenantCode, orgCode,
 					organization_code: defaults.orgCode,
 					model_names: { [Op.contains]: [modelName] },
 				}
-				const defaultEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(defaultFilter, [
-					defaults.tenantCode,
-				])
+				const defaultEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(
+					defaultFilter,
+					defaults.tenantCode
+				)
 				if (defaultEntityTypes && defaultEntityTypes.length > 0) {
 					// Merge defaults, avoiding duplicates by ID
 					const existingIds = new Set(allEntityTypes.map((et) => et.id))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Bug Fixes
  - Fixed Designation display in mentee and mentor lists by ensuring model_names queries using Sequelize's Op.contains receive the model name wrapped as an array so filters match correctly.
  - Standardized model_name parameter format for model-specific entity type queries (now consistently passed as single-element arrays where Op.contains is used).
  - Kept existing user-centric and defaults fallback logic intact while correcting the model_names matching to avoid missing designations.

### Changes by Author

| Author | Email | Lines Added | Lines Removed |
|--------|-------:|------------:|--------------:|
| sumanvpacewisdom | suman.v@pacewisdom.com | 1 | 1 |
| **Total** |  | **1** | **1** |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->