### PR TITLE
Refactor joinSession method to remove organization_code parameter and enhance session data retrieval.

### DIFF
--- a/src/controllers/v1/mentees.js
+++ b/src/controllers/v1/mentees.js
@@ -126,7 +126,6 @@ module.exports = class Mentees {
 			const session = await menteesService.joinSession(
 				req.params.id,
 				req.decodedToken.id,
-				req.decodedToken.organization_code,
 				req.decodedToken.tenant_code
 			)
 			return session

--- a/src/services/mentees.js
+++ b/src/services/mentees.js
@@ -448,7 +448,7 @@ module.exports = class MenteesHelper {
 	 * @returns {JSON} - Mentees join session link.
 	 */
 
-	static async joinSession(sessionId, userId, organizationCode, tenantCode) {
+	static async joinSession(sessionId, userId, tenantCode) {
 		try {
 			const mentee = await cacheHelper.mentee.get(tenantCode, userId)
 			if (!mentee) {
@@ -473,19 +473,27 @@ module.exports = class MenteesHelper {
 						attendee_meeting_info: sessionWithAttendee.meeting_info ?? sessionData.meeting_info,
 					}
 				}
+				// If mentee_password is missing from cache, fetch from database
+				if (!sessionData.mentee_password) {
+					const fullSessionData = await sessionQueries.findOne({ id: sessionId }, tenantCode)
+					if (fullSessionData?.mentee_password) {
+						sessionData.mentee_password = fullSessionData.mentee_password
+					}
+				}
 			} else {
+				// Cache miss: fetch session with attendee in a single query
 				sessionWithAttendee = await sessionQueries.findSessionWithAttendee(
 					sessionId,
 					mentee.user_id,
 					tenantCode
 				)
 
-				sessionData = { ...sessionWithAttendee }
-				// Normalize DB result to match cache structure
 				if (sessionWithAttendee) {
-					sessionWithAttendee.attendee_id = sessionWithAttendee.id
-					sessionWithAttendee.enrolled_type = sessionWithAttendee.enrolled_type || sessionWithAttendee.type
-					sessionWithAttendee.attendee_meeting_info = sessionWithAttendee.meeting_info
+					// Use the same object as sessionData since it already contains full session fields
+					// (including mentee_password, meeting_info, etc.) and attendee fields via attendeeData DTO
+					sessionData = { ...sessionWithAttendee }
+				} else {
+					sessionData = null
 				}
 			}
 
@@ -550,12 +558,24 @@ module.exports = class MenteesHelper {
 					result: meetingInfo,
 				})
 			}
+
 			if (sessionAttendeeExist?.meeting_info?.link) {
-				meetingInfo = sessionWithAttendee.meeting_info
+				// Existing BBB attendee link present in DB – just reuse it
+				meetingInfo = sessionAttendeeExist.meeting_info
 			} else {
+				// No existing link – generate a fresh one from BBB and store it
+				if (!sessionData.mentee_password) {
+					return responses.failureResponse({
+						message: 'MENTEE_PASSWORD_NOT_FOUND',
+						statusCode: httpStatusCode.bad_request,
+						responseCode: 'CLIENT_ERROR',
+					})
+				}
+
+				const menteeName = mentee.name || 'Attendee'
 				const attendeeLink = await bigBlueButtonService.joinMeetingAsAttendee(
 					sessionId,
-					mentee.name,
+					menteeName,
 					sessionData.mentee_password
 				)
 				meetingInfo = {


### PR DESCRIPTION
Added logic to fetch mentee_password from the database if missing from cache, and improved handling of meeting links for attendees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Removed `organization_code` parameter from the `joinSession` method signature, simplifying the API to accept only `sessionId`, `userId`, and `tenantCode`
- Added logic to fetch `mentee_password` from the database when it is missing from cache, ensuring complete session data retrieval
- Improved handling of meeting links for attendees, including fallback logic for attendee names and dynamic BBB meeting link generation
- Enhanced session data retrieval flow to consistently populate `sessionData` in both cache-hit and cache-miss paths
- Optimized attendee link reuse logic and added explicit guards against missing passwords during meeting link generation

## Contributor Statistics

| Author | Email | Lines Added | Lines Removed |
|--------|-------|-------------|---------------|
| sumanvpacewisdom | suman.v@pacewisdom.com | 2,608 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->