### PR TITLE
Bug 4512 User Delete issue

### DIFF
--- a/src/database/queries/mentorExtension.js
+++ b/src/database/queries/mentorExtension.js
@@ -153,38 +153,35 @@ module.exports = class MentorExtensionQueries {
 	}
 	static async removeMentorDetails(userId, tenantCode) {
 		try {
-			const modelAttributes = MentorExtension.rawAttributes
-
-			const fieldsToNullify = {}
-
-			for (const [key, attribute] of Object.entries(modelAttributes)) {
-				// Skip primary key or explicitly excluded fields
-				if (
-					attribute.primaryKey ||
-					key === 'user_id' ||
-					key === 'organization_id' || // required field
-					key === 'created_at' ||
-					key === 'updated_at' ||
-					key === 'is_mentor' // has default value
-				) {
-					continue
-				}
-
-				// Set types accordingly
-				if (attribute.type.constructor.name === 'ARRAY') {
-					fieldsToNullify[key] = []
-				} else if (attribute.type.key === 'JSON' || attribute.type.key === 'JSONB') {
-					fieldsToNullify[key] = {} // Or `{}` if you prefer default object
-				} else if (key === 'deleted_at') {
-					fieldsToNullify[key] = new Date() // Timestamp field
-				} else if (key === 'name') {
-					fieldsToNullify[key] = common.USER_NOT_FOUND
-				} else {
-					fieldsToNullify[key] = null
-				}
+			const fieldsToClear = {
+				designation: [],
+				area_of_expertise: [],
+				education_qualification: null,
+				rating: {},
+				meta: {},
+				stats: {},
+				tags: [],
+				configs: {},
+				visible_to_organizations: [],
+				external_session_visibility: null,
+				custom_entity_text: {},
+				experience: null,
+				external_mentee_visibility: null,
+				mentee_visibility: null,
+				external_mentor_visibility: null,
+				mentor_visibility: null,
+				name: common.USER_NOT_FOUND,
+				email: null,
+				phone: null,
+				settings: {},
+				image: null,
+				gender: null,
+				status: null,
+				username: null,
+				deleted_at: new Date(),
 			}
 
-			return await MentorExtension.update(fieldsToNullify, {
+			return await MentorExtension.update(fieldsToClear, {
 				where: {
 					user_id: userId,
 					tenant_code: tenantCode,

--- a/src/database/queries/sessions.js
+++ b/src/database/queries/sessions.js
@@ -318,16 +318,16 @@ exports.removeAndReturnMentorSessions = async (userId, tenantCode) => {
 
 		const foundSessions = await Session.findAll({
 			where: {
-				[Op.or]: [{ mentor_id: userId }, { created_by: userId }],
-				[Op.or]: [{ start_date: { [Op.gt]: currentEpochTime } }, { status: common.PUBLISHED_STATUS }],
+				// Op.and ensures both [Op.or] blocks are applied; duplicate object keys silently overwrite
+				[Op.and]: [
+					{ [Op.or]: [{ mentor_id: userId }, { created_by: userId }] },
+					{ [Op.or]: [{ start_date: { [Op.gt]: currentEpochTime } }, { status: common.PUBLISHED_STATUS }] },
+				],
 				tenant_code: tenantCode,
 			},
 			raw: true,
 		})
 
-		const sessionIdAndTitle = foundSessions.map((session) => {
-			return { id: session.id, title: session.title, start_date: session.start_date }
-		})
 		const upcomingSessionIds = foundSessions.map((session) => session.id)
 
 		const updatedSessions = await Session.update(
@@ -345,7 +345,15 @@ exports.removeAndReturnMentorSessions = async (userId, tenantCode) => {
 				},
 			}
 		)
-		const removedSessions = updatedSessions[0] > 0 ? sessionIdAndTitle : []
+
+		// Only return sessions that were actually soft-deleted (mentor is both creator and assigned mentor).
+		// Session-manager-created sessions (created_by != userId) are NOT deleted and must NOT be included
+		// here, or their attendees would be incorrectly unenrolled.
+		const deletedSessionIdAndTitle = foundSessions
+			.filter((s) => String(s.mentor_id) === String(userId) && String(s.created_by) === String(userId))
+			.map((session) => ({ id: session.id, title: session.title, start_date: session.start_date }))
+
+		const removedSessions = updatedSessions[0] > 0 ? deletedSessionIdAndTitle : []
 		return removedSessions
 	} catch (error) {
 		return error
@@ -1073,15 +1081,16 @@ exports.getUpcomingSessionsForMentor = async (mentorUserId, tenantCode) => {
 
 exports.getSessionsAssignedToMentor = async (mentorUserId, tenantCode) => {
 	try {
+		// Citus requires tenant_code in JOIN ON clause for co-located distributed tables
 		const query = `
 				SELECT s.*, sa.mentee_id
 				FROM ${Session.tableName} s
 				LEFT JOIN session_attendees sa ON s.id = sa.session_id
-				WHERE s.mentor_id = :mentorUserId 
+				AND s.tenant_code = sa.tenant_code
+				WHERE s.mentor_id = :mentorUserId
+				AND s.start_date > :currentTime
+				AND s.deleted_at IS NULL
 				AND s.tenant_code = :tenantCode
-				AND s.start_date > :currentTime
-				AND s.deleted_at IS NULL
-				AND s.created_by = :mentorUserId
 			`
 
 		const sessionsToDelete = await Sequelize.query(query, {
@@ -1089,32 +1098,7 @@ exports.getSessionsAssignedToMentor = async (mentorUserId, tenantCode) => {
 			replacements: {
 				mentorUserId,
 				currentTime: Math.floor(Date.now() / 1000),
-				tenantCode: tenantCode,
-			},
-		})
-
-		return sessionsToDelete
-	} catch (error) {
-		throw error
-	}
-}
-
-exports.getSessionsAssignedToMentor = async (mentorUserId) => {
-	try {
-		const query = `
-				SELECT s.*, sa.mentee_id
-				FROM ${Session.tableName} s
-				LEFT JOIN session_attendees sa ON s.id = sa.session_id
-				WHERE s.mentor_id = :mentorUserId 
-				AND s.start_date > :currentTime
-				AND s.deleted_at IS NULL
-			`
-
-		const sessionsToDelete = await Sequelize.query(query, {
-			type: QueryTypes.SELECT,
-			replacements: {
-				mentorUserId,
-				currentTime: Math.floor(Date.now() / 1000),
+				tenantCode,
 			},
 		})
 

--- a/src/database/queries/userExtension.js
+++ b/src/database/queries/userExtension.js
@@ -238,38 +238,35 @@ module.exports = class MenteeExtensionQueries {
 
 	static async removeMenteeDetails(userId, tenantCode) {
 		try {
-			const modelAttributes = MenteeExtension.rawAttributes
-
-			const fieldsToNullify = {}
-
-			for (const [key, attribute] of Object.entries(modelAttributes)) {
-				// Skip primary key or explicitly excluded fields
-				if (
-					attribute.primaryKey ||
-					key === 'user_id' ||
-					key === 'organization_id' || // required field
-					key === 'created_at' ||
-					key === 'updated_at' ||
-					key === 'is_mentor' // has default value
-				) {
-					continue
-				}
-
-				// Set types accordingly
-				if (attribute.type.constructor.name === 'ARRAY') {
-					fieldsToNullify[key] = []
-				} else if (attribute.type.key === 'JSON' || attribute.type.key === 'JSONB') {
-					fieldsToNullify[key] = {} // Or `{}` if you prefer default object
-				} else if (key === 'deleted_at') {
-					fieldsToNullify[key] = new Date() // Timestamp field
-				} else if (key === 'name') {
-					fieldsToNullify[key] = common.USER_NOT_FOUND
-				} else {
-					fieldsToNullify[key] = null
-				}
+			const fieldsToClear = {
+				designation: [],
+				area_of_expertise: [],
+				education_qualification: null,
+				rating: {},
+				meta: {},
+				stats: {},
+				tags: [],
+				configs: {},
+				visible_to_organizations: [],
+				external_session_visibility: null,
+				custom_entity_text: {},
+				experience: null,
+				external_mentee_visibility: null,
+				mentee_visibility: null,
+				external_mentor_visibility: null,
+				mentor_visibility: null,
+				name: common.USER_NOT_FOUND,
+				email: null,
+				phone: null,
+				settings: {},
+				image: null,
+				gender: null,
+				status: null,
+				username: null,
+				deleted_at: new Date(),
 			}
 
-			return await MenteeExtension.update(fieldsToNullify, {
+			return await MenteeExtension.update(fieldsToClear, {
 				where: {
 					user_id: userId,
 					tenant_code: tenantCode,

--- a/src/helpers/getDefaultOrgId.js
+++ b/src/helpers/getDefaultOrgId.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const userRequests = require('@requests/user')
-
 /**
  * Retrieves the default organization code.
  * @returns {Promise<string|null>} Default organization code or null if not found.
@@ -14,16 +12,6 @@ exports.getDefaults = async () => {
 				orgCode: DEFAULT_ORGANISATION_CODE,
 				tenantCode: DEFAULT_TENANT_CODE,
 			}
-		}
-
-		const { success, data } = await userRequests.fetchOrgDetails({
-			organizationCode: DEFAULT_ORGANISATION_CODE,
-			tenantCode: DEFAULT_TENANT_CODE,
-		})
-
-		return {
-			orgCode: success && data?.result?.code,
-			tenantCode: data?.result?.tenant_code,
 		}
 	} catch (err) {
 		console.error('Error in getDefaults:', err)

--- a/src/requests/user.js
+++ b/src/requests/user.js
@@ -14,12 +14,11 @@ const httpStatusCode = require('@generics/http-status')
 const responses = require('@helpers/responses')
 const common = require('@constants/common')
 const { Op } = require('sequelize')
-const cacheHelper = require('@generics/cacheHelper')
 const usersHelper = require('@helpers/users')
+const cacheHelper = require('@generics/cacheHelper')
 
 const menteeQueries = require('@database/queries/userExtension')
 const organisationExtensionQueries = require('@database/queries/organisationExtension')
-// Removed cacheHelper to break circular dependency with getDefaultOrgId
 
 const emailEncryption = require('@utils/emailEncryption')
 const _ = require('lodash')

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -37,6 +37,7 @@ class NotificationHelper {
 		templateData = {},
 		subjectData = {},
 		tenantCode,
+		tenantCodes, // accept plural form used by many callers
 	}) {
 		try {
 			if (!templateCode || !recipients?.length) {
@@ -44,8 +45,10 @@ class NotificationHelper {
 				return true
 			}
 
+			// Support both tenantCode (singular) and tenantCodes (plural) from callers
+			const effectiveTenantCode = tenantCode || tenantCodes
 			// Handle arrays: extract first value (user codes), cacheHelper will fallback to defaults if not found
-			const userTenantCode = Array.isArray(tenantCode) ? tenantCode[0] : tenantCode
+			const userTenantCode = Array.isArray(effectiveTenantCode) ? effectiveTenantCode[0] : effectiveTenantCode
 			const userOrgCode = Array.isArray(orgCode) ? orgCode[0] : orgCode
 
 			// cacheHelper.get will automatically search user codes first, then defaults when cache is disabled
@@ -170,7 +173,7 @@ module.exports = class AdminService {
 			let result = {}
 
 			// Step 1: Fetch user details
-			let getUserDetails = []
+			let userInfo = null
 			let userTenantCode = tenantCode
 
 			// Optimization: If admin, query directly without tenant restriction (1 query)
@@ -179,21 +182,20 @@ module.exports = class AdminService {
 				// Admin deleting any user - no tenant code restriction
 				const userDetail = await menteeQueries.getMenteeExtensionById(userId, [], true)
 				userTenantCode = userDetail?.tenant_code
-				getUserDetails = userDetail ? [userDetail] : []
+				userInfo = userDetail || null
 			} else {
 				// Regular user deleting themselves - use tenant code from token (optimized path)
-				getUserDetails = await menteeQueries.getUsersByUserIds([userId], {}, tenantCode)
+				const getUserDetails = await menteeQueries.getUsersByUserIds([userId], {}, tenantCode)
+				userInfo = getUserDetails?.[0]
 			}
 
-			if (!getUserDetails || getUserDetails.length === 0) {
+			if (!userInfo) {
 				return responses.failureResponse({
 					statusCode: httpStatusCode.bad_request,
 					message: 'USER_NOT_FOUND',
 					result,
 				})
 			}
-
-			const userInfo = getUserDetails[0]
 			const isMentor = userInfo.is_mentor === true
 
 			// Step 2: Check if user is a session manager
@@ -763,10 +765,13 @@ module.exports = class AdminService {
 			const sentRequestsData = sentRequests.rows || []
 
 			// Get requests where user is requestee (received requests)
-			const sessionRequestMapping = await sessionRequestMappingQueries.getSessionsMapping(userId, tenantCode)
-			const sessionRequestIds = Array.isArray(sessionRequestMapping)
-				? sessionRequestMapping.map((s) => s.request_session_id)
-				: []
+			// Correct arg order: (userId, status, tenantCode) — pass null to get all statuses
+			const sessionRequestMapping = await sessionRequestMappingQueries.getSessionsMapping(
+				userId,
+				null,
+				tenantCode
+			)
+			const sessionRequestIds = Array.isArray(sessionRequestMapping) ? sessionRequestMapping.map((s) => s.id) : []
 
 			const receivedRequests = await requestSessionQueries.getSessionMappingDetails(
 				sessionRequestIds,
@@ -1421,24 +1426,14 @@ module.exports = class AdminService {
 
 	static async getPendingSessionRequestsForMentor(mentorUserId, tenantCode) {
 		try {
-			const query = `
-				SELECT rs.*, rm.requestee_id
-				FROM ${RequestSession.tableName} rs
-				INNER JOIN request_session_mapping rm ON rs.id = rm.request_session_id
-				WHERE rm.requestee_id = :mentorUserId 
-				AND rs.status = :requestedStatus
-				AND rs.deleted_at IS NULL
-				AND rs.tenant_code = :tenantCode
-				AND rm.tenant_code = :tenantCode
-			`
-
-			const pendingRequests = await sequelize.query(query, {
-				type: QueryTypes.SELECT,
-				replacements: {
-					mentorUserId,
-					requestedStatus: common.CONNECTIONS_STATUS.REQUESTED,
-					tenantCode,
+			// request_session_mapping table no longer exists; requestee_id is directly on session_request
+			const pendingRequests = await RequestSession.findAll({
+				where: {
+					requestee_id: mentorUserId,
+					status: common.CONNECTIONS_STATUS.REQUESTED,
+					tenant_code: tenantCode,
 				},
+				raw: true,
 			})
 
 			return pendingRequests || []

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -36,8 +36,7 @@ class NotificationHelper {
 		orgCode,
 		templateData = {},
 		subjectData = {},
-		tenantCode,
-		tenantCodes, // accept plural form used by many callers
+		tenantCodes,
 	}) {
 		try {
 			if (!templateCode || !recipients?.length) {
@@ -45,10 +44,8 @@ class NotificationHelper {
 				return true
 			}
 
-			// Support both tenantCode (singular) and tenantCodes (plural) from callers
-			const effectiveTenantCode = tenantCode || tenantCodes
 			// Handle arrays: extract first value (user codes), cacheHelper will fallback to defaults if not found
-			const userTenantCode = Array.isArray(effectiveTenantCode) ? effectiveTenantCode[0] : effectiveTenantCode
+			const userTenantCode = Array.isArray(tenantCodes) ? tenantCodes[0] : tenantCodes
 			const userOrgCode = Array.isArray(orgCode) ? orgCode[0] : orgCode
 
 			// cacheHelper.get will automatically search user codes first, then defaults when cache is disabled
@@ -765,7 +762,6 @@ module.exports = class AdminService {
 			const sentRequestsData = sentRequests.rows || []
 
 			// Get requests where user is requestee (received requests)
-			// Correct arg order: (userId, status, tenantCode) — pass null to get all statuses
 			const sessionRequestMapping = await sessionRequestMappingQueries.getSessionsMapping(
 				userId,
 				null,
@@ -1426,7 +1422,6 @@ module.exports = class AdminService {
 
 	static async getPendingSessionRequestsForMentor(mentorUserId, tenantCode) {
 		try {
-			// request_session_mapping table no longer exists; requestee_id is directly on session_request
 			const pendingRequests = await RequestSession.findAll({
 				where: {
 					requestee_id: mentorUserId,

--- a/src/services/default-rule.js
+++ b/src/services/default-rule.js
@@ -180,7 +180,7 @@ module.exports = class DefaultRuleHelper {
 								roles: roles,
 								requesterOrganizationCode: orgCode,
 								data: requestedUserExtension,
-								tenant_code: tenantCode,
+								tenantCode: tenantCode,
 							})
 
 							if (!validateDefaultRules) {
@@ -212,7 +212,7 @@ module.exports = class DefaultRuleHelper {
 									roles: roles,
 									requesterOrganizationCode: orgCode,
 									data: requestedUserExtension,
-									tenant_code: tenantCode,
+									tenantCode: tenantCode,
 								})
 
 								if (!validateDefaultRules) {

--- a/src/services/mentees.js
+++ b/src/services/mentees.js
@@ -2100,7 +2100,7 @@ module.exports = class MenteesHelper {
 						roles: roles,
 						requesterOrganizationCode: organizationCode,
 						data: cacheProfileDetails,
-						tenant_code: tenantCode,
+						tenantCode: tenantCode,
 					})
 					if (validateDefaultRules.error && validateDefaultRules.error.missingField) {
 						return responses.failureResponse({
@@ -2180,7 +2180,7 @@ module.exports = class MenteesHelper {
 					roles: roles,
 					requesterOrganizationCode: organizationCode,
 					data: requestedUserExtension,
-					tenant_code: tenantCode,
+					tenantCode: tenantCode,
 				})
 				if (validateDefaultRules.error && validateDefaultRules.error.missingField) {
 					return responses.failureResponse({

--- a/src/services/mentors.js
+++ b/src/services/mentors.js
@@ -832,7 +832,7 @@ module.exports = class MentorsHelper {
 						roles: roles,
 						requesterOrganizationCode: orgCode,
 						data: requestedMentorExtension,
-						tenant_code: tenantCode,
+						tenantCode: tenantCode,
 					})
 					if (validateDefaultRules.error && validateDefaultRules.error.missingField) {
 						return responses.failureResponse({
@@ -926,7 +926,7 @@ module.exports = class MentorsHelper {
 					roles: roles,
 					requesterOrganizationCode: orgCode,
 					data: mentorExtension,
-					tenant_code: tenantCode,
+					tenantCode: tenantCode,
 				})
 				if (validateDefaultRules.error && validateDefaultRules.error.missingField) {
 					return responses.failureResponse({

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -133,7 +133,10 @@ module.exports = class OrgAdminService {
 					responseCode: 'CLIENT_ERROR',
 				})
 			// Delete upcoming sessions of user as mentor
-			const removedSessionsDetail = await sessionQueries.removeAndReturnMentorSessions(bodyData.user_id)
+			const removedSessionsDetail = await sessionQueries.removeAndReturnMentorSessions(
+				bodyData.user_id,
+				tenantCode
+			)
 
 			if (removedSessionsDetail && removedSessionsDetail.length > 0) {
 				for (const userSession of removedSessionsDetail) {

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1497,7 +1497,7 @@ module.exports = class SessionsHelper {
 								roles: roles,
 								requesterOrganizationCode: orgCode,
 								data: sessionDetailedResponse,
-								tenant_code: tenantCode,
+								tenantCode: tenantCode,
 							})
 						}
 						if (validateDefaultRules?.error && validateDefaultRules?.error?.missingField) {
@@ -1595,7 +1595,7 @@ module.exports = class SessionsHelper {
 						roles: roles,
 						requesterOrganizationCode: orgCode,
 						data: sessionDetails,
-						tenant_code: tenantCode,
+						tenantCode: tenantCode,
 					})
 				}
 				if (validateDefaultRules?.error && validateDefaultRules?.error?.missingField) {
@@ -2066,7 +2066,7 @@ module.exports = class SessionsHelper {
 					roles: roles,
 					requesterOrganizationCode: orgCode,
 					data: session,
-					tenant_code: tenantCode,
+					tenantCode: tenantCode,
 				})
 			}
 			if (validateDefaultRules?.error && validateDefaultRules?.error?.missingField) {

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -918,7 +918,12 @@ module.exports = class SessionsHelper {
 					mentorUpdated = true
 					const newMentor =
 						(await cacheHelper.mentor.getCacheOnly(tenantCode, bodyData.mentor_id)) ??
-						(await mentorExtensionQueries.getMentorExtension(bodyData.mentor_id, ['name'], true))
+						(await mentorExtensionQueries.getMentorExtension(
+							bodyData.mentor_id,
+							['name'],
+							false,
+							tenantCode
+						))
 					if (newMentor?.name) {
 						bodyData.mentor_name = newMentor.name
 					}
@@ -4148,7 +4153,7 @@ module.exports = class SessionsHelper {
 				}
 
 				if (!mentor) {
-					mentor = await mentorQueries.getMentorExtension(mentorId, ['organization_code'], tenantCode)
+					mentor = await mentorQueries.getMentorExtension(mentorId, ['organization_code'], false, tenantCode)
 				}
 				if (!mentor) throw new MentorError('Invalid Mentor Id', { mentorId })
 


### PR DESCRIPTION
Refactor mentor and mentee detail removal logic to use a unified fields clearing approach, enhancing code clarity and maintainability. Update session queries to ensure correct tenant code handling and improve session deletion logic for better accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Refactored mentor and mentee detail removal logic to use unified fieldsToClear objects that explicitly specify fields and their reset values, improving clarity and maintainability.
- Ensured tenant-aware session queries and mentor-extension fetches by switching to tenantCode (camelCase) across session helpers and queries for multi-tenant correctness.
- Improved session deletion logic to only report/remove sessions where the mentor is both creator and assigned mentor, refining deletion accuracy.
- Updated NotificationHelper.sendGenericNotification to accept a plural tenantCodes parameter alongside tenantCode (public API change).
- Simplified AdminService.userDelete flow by switching from array-based user retrieval to a single-user object (userInfo).
- Replaced raw SQL with Sequelize queries for pending session request retrieval and adjusted related argument ordering and mappings.
- Removed external userRequests dependency from getDefaultOrgId, relying on environment defaults instead.
- Updated various service calls and payloads to use tenantCode (camelCase) consistently (affects default-rule, mentees, mentors, sessions, and related helpers).
- Adjusted mentor extension fetch signature to accept tenantCode as an additional parameter.

## Lines Changed by Author

| Author | Added | Removed |
|--------|------:|--------:|
| sumanvpacewisdom | 115 | 152 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->