### PR TITLE
tenant isolation - phase 2 branch

### DIFF
--- a/src/controllers/v1/org-admin.js
+++ b/src/controllers/v1/org-admin.js
@@ -70,7 +70,7 @@ module.exports = class OrgAdmin {
 			let entityTypeDetails = await orgAdminService.inheritEntityType(
 				req.body.entity_type_value,
 				req.body.target_entity_type_label,
-				req.decodedToken.organization_id,
+				req.decodedToken.organization_code,
 				req.decodedToken,
 				req.decodedToken.tenant_code
 			)

--- a/src/controllers/v1/org-admin.js
+++ b/src/controllers/v1/org-admin.js
@@ -70,7 +70,7 @@ module.exports = class OrgAdmin {
 			let entityTypeDetails = await orgAdminService.inheritEntityType(
 				req.body.entity_type_value,
 				req.body.target_entity_type_label,
-				req.decodedToken.organization_code,
+				req.decodedToken.organization_id,
 				req.decodedToken,
 				req.decodedToken.tenant_code
 			)

--- a/src/database/queries/entity.js
+++ b/src/database/queries/entity.js
@@ -126,7 +126,7 @@ module.exports = class UserEntityData {
 			let whereClause = {
 				...filters,
 				// MANDATORY: Include tenant_code filtering
-				tenant_code: Array.isArray(tenantCode) ? { [Op.in]: tenantCode } : tenantCode,
+				tenant_code: tenantCode,
 			}
 
 			if (search) {

--- a/src/database/queries/entityType.js
+++ b/src/database/queries/entityType.js
@@ -13,11 +13,11 @@ module.exports = class UserEntityData {
 		}
 	}
 
-	static async findOneEntityType(filter, tenantCodes, options = {}) {
+	static async findOneEntityType(filter, tenantCode, options = {}) {
 		try {
 			const whereClause = {
 				...filter,
-				tenant_code: tenantCodes,
+				tenant_code: tenantCode,
 			}
 
 			// Safe merge: tenant filtering cannot be overridden by options.where
@@ -36,11 +36,11 @@ module.exports = class UserEntityData {
 		}
 	}
 
-	static async findAllEntityTypes(orgCodes, tenantCodes, attributes, filter = {}) {
+	static async findAllEntityTypes(orgCodes, tenantCode, attributes, filter = {}) {
 		try {
 			const whereClause = {
-				tenant_code: tenantCodes,
 				...filter,
+				tenant_code: tenantCode,
 			}
 
 			// Only apply org filter when a real value is provided (skip empty object {})
@@ -61,11 +61,11 @@ module.exports = class UserEntityData {
 			throw error
 		}
 	}
-	static async findUserEntityTypesAndEntities(filter, tenantCodes) {
+	static async findUserEntityTypesAndEntities(filter, tenantCode) {
 		try {
 			const whereClause = {
 				...filter,
-				tenant_code: Array.isArray(tenantCodes) ? { [Op.in]: tenantCodes } : tenantCodes,
+				tenant_code: tenantCode,
 			}
 
 			const entityTypes = await EntityType.findAll({
@@ -80,7 +80,7 @@ module.exports = class UserEntityData {
 				const entityFilter = {
 					entity_type_id: entityTypeIds,
 					status: 'ACTIVE',
-					tenant_code: tenantCodes,
+					tenant_code: tenantCode,
 				}
 
 				entities = await Entity.findAll({

--- a/src/database/queries/entityType.js
+++ b/src/database/queries/entityType.js
@@ -38,12 +38,21 @@ module.exports = class UserEntityData {
 
 	static async findAllEntityTypes(orgCodes, tenantCodes, attributes, filter = {}) {
 		try {
+			const whereClause = {
+				tenant_code: tenantCodes,
+				...filter,
+			}
+
+			// Only apply org filter when a real value is provided (skip empty object {})
+			const hasOrgFilter =
+				orgCodes &&
+				(Array.isArray(orgCodes) || typeof orgCodes !== 'object' || Object.keys(orgCodes).length > 0)
+			if (hasOrgFilter) {
+				whereClause.organization_code = orgCodes
+			}
+
 			const entityData = await EntityType.findAll({
-				where: {
-					organization_code: orgCodes,
-					tenant_code: tenantCodes,
-					...filter,
-				},
+				where: whereClause,
 				attributes,
 				raw: true,
 			})

--- a/src/database/queries/entityType.js
+++ b/src/database/queries/entityType.js
@@ -46,7 +46,7 @@ module.exports = class UserEntityData {
 			// Only apply org filter when a real value is provided (skip empty object {})
 			const hasOrgFilter =
 				orgCodes &&
-				(Array.isArray(orgCodes) || typeof orgCodes !== 'object' || Object.keys(orgCodes).length > 0)
+				(Array.isArray(orgCodes) || typeof orgCodes !== 'object' || Reflect.ownKeys(orgCodes).length > 0)
 			if (hasOrgFilter) {
 				whereClause.organization_code = orgCodes
 			}

--- a/src/database/queries/form.js
+++ b/src/database/queries/form.js
@@ -33,11 +33,11 @@ module.exports = class FormsData {
 		}
 	}
 
-	static async findFormsByFilter(filter, tenantCodes, options = {}) {
+	static async findFormsByFilter(filter, tenantCode, options = {}) {
 		try {
 			const whereClause = {
 				...filter,
-				tenant_code: { [Op.in]: tenantCodes },
+				tenant_code: tenantCode,
 			}
 
 			// Safe merge: tenant filtering cannot be overridden by options.where

--- a/src/database/queries/notificationTemplate.js
+++ b/src/database/queries/notificationTemplate.js
@@ -38,12 +38,8 @@ module.exports = class NotificationTemplateData {
 				...filter,
 			}
 
-			// Handle array values for organization_code and tenant_code
 			if (Array.isArray(filter.organization_code)) {
 				whereClause.organization_code = { [Op.in]: filter.organization_code }
-			}
-			if (Array.isArray(filter.tenant_code)) {
-				whereClause.tenant_code = { [Op.in]: filter.tenant_code }
 			}
 
 			// Safe merge: tenant filtering cannot be overridden by options.where
@@ -93,13 +89,12 @@ module.exports = class NotificationTemplateData {
 		}
 	}
 
-	static async findOneEmailTemplate(code, orgCodeParam, tenantCodeParam) {
+	static async findOneEmailTemplate(code, orgCodeParam, tenantCode) {
 		try {
 			// Direct database query - cache logic moved to caller level
 
 			// Handle different parameter formats that callers might use
 			let orgCodes = []
-			let tenantCodes = []
 
 			// Parse organization codes
 			if (Array.isArray(orgCodeParam)) {
@@ -110,22 +105,13 @@ module.exports = class NotificationTemplateData {
 				orgCodes = [orgCodeParam]
 			}
 
-			// Parse tenant codes
-			if (Array.isArray(tenantCodeParam)) {
-				tenantCodes = tenantCodeParam
-			} else if (tenantCodeParam && typeof tenantCodeParam === 'object' && tenantCodeParam[Op.in]) {
-				tenantCodes = tenantCodeParam[Op.in]
-			} else if (tenantCodeParam) {
-				tenantCodes = [tenantCodeParam]
-			}
-
 			// Build filter for template search
 			const filter = {
 				code: code,
 				type: 'email',
 				status: 'active',
 				organization_code: { [Op.in]: orgCodes },
-				tenant_code: { [Op.in]: tenantCodes },
+				tenant_code: tenantCode,
 			}
 
 			let templateData = await NotificationTemplate.findAll({
@@ -137,49 +123,21 @@ module.exports = class NotificationTemplateData {
 				return null
 			}
 
-			// Business logic: Prefer current tenant/org over defaults
-			// Priority: exact match > org match > tenant match > default
-			let selectedTemplate = templateData[0] // fallback
-
-			// Try to find exact match first
-			const exactMatch = templateData.find(
-				(template) =>
-					template.organization_code === (Array.isArray(orgCodeParam) ? orgCodeParam[0] : orgCodeParam) &&
-					template.tenant_code === (Array.isArray(tenantCodeParam) ? tenantCodeParam[0] : tenantCodeParam)
-			)
-			if (exactMatch) {
-				selectedTemplate = exactMatch
-			} else {
-				// Try org match
-				const orgMatch = templateData.find(
-					(template) =>
-						template.organization_code === (Array.isArray(orgCodeParam) ? orgCodeParam[0] : orgCodeParam)
-				)
-				if (orgMatch) {
-					selectedTemplate = orgMatch
-				} else {
-					// Try tenant match
-					const tenantMatch = templateData.find(
-						(template) =>
-							template.tenant_code ===
-							(Array.isArray(tenantCodeParam) ? tenantCodeParam[0] : tenantCodeParam)
-					)
-					if (tenantMatch) {
-						selectedTemplate = tenantMatch
-					}
-				}
-			}
+			// Priority: user's org template > default org template
+			const userOrgCode = Array.isArray(orgCodeParam) ? orgCodeParam[0] : orgCodeParam
+			const orgMatch = templateData.find((template) => template.organization_code === userOrgCode)
+			const selectedTemplate = orgMatch || templateData[0]
 
 			// Compose template with header and footer
 			if (selectedTemplate && selectedTemplate.email_header) {
-				const header = await this.getEmailHeader(selectedTemplate.email_header, tenantCodes, orgCodes)
+				const header = await this.getEmailHeader(selectedTemplate.email_header, tenantCode, orgCodes)
 				if (header && header.body) {
 					selectedTemplate.body = header.body + selectedTemplate.body
 				}
 			}
 
 			if (selectedTemplate && selectedTemplate.email_footer) {
-				const footer = await this.getEmailFooter(selectedTemplate.email_footer, tenantCodes, orgCodes)
+				const footer = await this.getEmailFooter(selectedTemplate.email_footer, tenantCode, orgCodes)
 				if (footer && footer.body) {
 					selectedTemplate.body += footer.body
 				}
@@ -193,57 +151,39 @@ module.exports = class NotificationTemplateData {
 		}
 	}
 
-	static async getEmailHeader(headerCode, tenantCodes = [], orgCodes = []) {
+	static async getEmailHeader(headerCode, tenantCode, orgCodes = []) {
 		try {
-			const normalizedTenantCodes = Array.isArray(tenantCodes)
-				? tenantCodes.filter(Boolean)
-				: [tenantCodes].filter(Boolean)
 			const normalizedOrgCodes = Array.isArray(orgCodes) ? orgCodes.filter(Boolean) : [orgCodes].filter(Boolean)
 			const where = {
 				code: headerCode,
 				type: 'emailHeader',
 				status: 'active',
+				tenant_code: tenantCode,
 			}
-			if (normalizedTenantCodes.length > 0) where.tenant_code = { [Op.in]: normalizedTenantCodes }
 			if (normalizedOrgCodes.length > 0) where.organization_code = { [Op.in]: normalizedOrgCodes }
 			const results = await NotificationTemplate.findAll({ where, raw: true })
 			if (!results || results.length === 0) return null
 			const preferredOrg = normalizedOrgCodes[0]
-			const preferredTenant = normalizedTenantCodes[0]
-			return (
-				results.find((r) => r.organization_code === preferredOrg && r.tenant_code === preferredTenant) ||
-				results.find((r) => r.organization_code === preferredOrg) ||
-				results.find((r) => r.tenant_code === preferredTenant) ||
-				results[0]
-			)
+			return results.find((r) => r.organization_code === preferredOrg) || results[0]
 		} catch (error) {
 			return null
 		}
 	}
 
-	static async getEmailFooter(footerCode, tenantCodes = [], orgCodes = []) {
+	static async getEmailFooter(footerCode, tenantCode, orgCodes = []) {
 		try {
-			const normalizedTenantCodes = Array.isArray(tenantCodes)
-				? tenantCodes.filter(Boolean)
-				: [tenantCodes].filter(Boolean)
 			const normalizedOrgCodes = Array.isArray(orgCodes) ? orgCodes.filter(Boolean) : [orgCodes].filter(Boolean)
 			const where = {
 				code: footerCode,
 				type: 'emailFooter',
 				status: 'active',
+				tenant_code: tenantCode,
 			}
-			if (normalizedTenantCodes.length > 0) where.tenant_code = { [Op.in]: normalizedTenantCodes }
 			if (normalizedOrgCodes.length > 0) where.organization_code = { [Op.in]: normalizedOrgCodes }
 			const results = await NotificationTemplate.findAll({ where, raw: true })
 			if (!results || results.length === 0) return null
 			const preferredOrg = normalizedOrgCodes[0]
-			const preferredTenant = normalizedTenantCodes[0]
-			return (
-				results.find((r) => r.organization_code === preferredOrg && r.tenant_code === preferredTenant) ||
-				results.find((r) => r.organization_code === preferredOrg) ||
-				results.find((r) => r.tenant_code === preferredTenant) ||
-				results[0]
-			)
+			return results.find((r) => r.organization_code === preferredOrg) || results[0]
 		} catch (error) {
 			return null
 		}

--- a/src/database/queries/reportRoleMapping.js
+++ b/src/database/queries/reportRoleMapping.js
@@ -56,12 +56,12 @@ module.exports = class ReportRoleMappingQueries {
 		}
 	}
 
-	static async findReportRoleMappingByReportCode(reportCode, tenantCodes, organizationCodes) {
+	static async findReportRoleMappingByReportCode(reportCode, tenantCode, organizationCodes) {
 		try {
 			return await ReportRoleMapping.findOne({
 				where: {
 					report_code: reportCode,
-					tenant_code: { [Op.in]: tenantCodes },
+					tenant_code: tenantCode,
 					organization_code: { [Op.in]: organizationCodes },
 				},
 			})

--- a/src/database/queries/reportTypes.js
+++ b/src/database/queries/reportTypes.js
@@ -31,13 +31,13 @@ module.exports = class ReportTypeQueries {
 		}
 	}
 
-	static async findReportTypesByTitle(title, tenantCodes, options = {}) {
+	static async findReportTypesByTitle(title, tenantCode, options = {}) {
 		try {
 			const { where: optionsWhere = {}, ...rest } = options || {}
 			const where = {
 				...optionsWhere,
 				title: title,
-				tenant_code: { [Op.in]: tenantCodes },
+				tenant_code: tenantCode,
 			}
 
 			return await ReportType.findAll({

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -13,7 +13,6 @@ const notificationTemplateQueries = require('@database/queries/notificationTempl
 const sessionQueries = require('@database/queries/sessions')
 const permissionQueries = require('@database/queries/permissions')
 const rolePermissionMappingQueries = require('@database/queries/role-permission-mapping')
-const { getDefaults } = require('@helpers/getDefaultOrgId')
 const kafkaCommunication = require('@generics/kafka-communication')
 // Removed SessionsHelper import to avoid circular dependency
 const formQueries = require('@database/queries/form')
@@ -544,20 +543,7 @@ const entityTypes = {
 				return cachedEntityType
 			}
 
-			// Step 2: Get defaults internally for database query
-			let defaults = null
-			try {
-				defaults = await getDefaults()
-			} catch (error) {
-				console.error('Failed to get defaults for entityType cache:', error.message)
-				// Fallback defaults from environment variables
-				defaults = {
-					orgCode: process.env.DEFAULT_ORGANISATION_CODE || 'default_code',
-					tenantCode: process.env.DEFAULT_TENANT_CODE || 'default',
-				}
-			}
-
-			// Step 3: Cache miss - query database with user codes first
+			// Step 2: Cache miss - query database with user codes
 			console.log(
 				`💾 EntityType ${modelName}:${entityValue} cache miss, querying database with user codes: tenant:${tenantCode}:org:${orgCode}`
 			)
@@ -641,18 +627,6 @@ const entityTypes = {
 	async getAllEntityTypesForModel(tenantCode, orgCode, modelName) {
 		try {
 			// Get defaults internally for database query
-			let defaults = null
-			try {
-				defaults = await getDefaults()
-			} catch (error) {
-				console.error('Failed to get defaults for getAllEntityTypesForModel:', error.message)
-				// Fallback defaults from environment variables
-				defaults = {
-					orgCode: process.env.DEFAULT_ORGANISATION_CODE || 'default_code',
-					tenantCode: process.env.DEFAULT_TENANT_CODE || 'default',
-				}
-			}
-
 			let entityTypes = []
 			try {
 				// Step 1: Fetch from user tenant and org codes
@@ -764,20 +738,7 @@ const forms = {
 				return cachedForm
 			}
 
-			// Step 2: Get defaults internally for database query
-			let defaults = null
-			try {
-				defaults = await getDefaults()
-			} catch (error) {
-				console.error('Failed to get defaults for form cache:', error.message)
-				// Fallback defaults from environment variables
-				defaults = {
-					orgCode: process.env.DEFAULT_ORGANISATION_CODE || 'default_code',
-					tenantCode: process.env.DEFAULT_TENANT_CODE || 'default',
-				}
-			}
-
-			// Step 3: Cache miss - query database with user codes first
+			// Step 2: Cache miss - query database with user codes
 			console.log(
 				`💾 Form ${type}:${subtype} cache miss, querying database with user codes: tenant:${tenantCode}:org:${orgCode}`
 			)
@@ -1446,20 +1407,7 @@ const notificationTemplates = {
 				return cachedTemplate
 			}
 
-			// Step 2: Get defaults internally for database query
-			let defaults = null
-			try {
-				defaults = await getDefaults()
-			} catch (error) {
-				console.error('Failed to get defaults for notification template cache:', error.message)
-				// Fallback defaults from environment variables
-				defaults = {
-					orgCode: process.env.DEFAULT_ORGANISATION_CODE || 'default_code',
-					tenantCode: process.env.DEFAULT_TENANT_CODE || 'default',
-				}
-			}
-
-			// Step 3: Cache miss - query database with prioritized fallback logic
+			// Step 2: Cache miss - query database with user codes
 
 			let templateFromDb = null
 			try {

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -581,39 +581,7 @@ const entityTypes = {
 					)
 				}
 
-				// Step 2: ALSO fetch from default codes (if different from user codes)
-				if (
-					defaults &&
-					defaults.orgCode &&
-					defaults.tenantCode &&
-					(defaults.tenantCode !== tenantCode || defaults.orgCode !== orgCode)
-				) {
-					console.log(
-						`💾 EntityType ${modelName}:${entityValue} also fetching from defaults: tenant:${defaults.tenantCode}:org:${defaults.orgCode}`
-					)
-
-					const defaultFilter = {
-						status: 'ACTIVE',
-						organization_code: defaults.orgCode,
-						model_names: { [Op.contains]: modelName },
-					}
-					if (entityValue) {
-						defaultFilter.value = entityValue
-					}
-					const defaultEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(
-						defaultFilter,
-						defaults.tenantCode
-					)
-					if (defaultEntityTypes && defaultEntityTypes.length > 0) {
-						// Merge defaults, avoiding duplicates by ID
-						const existingIds = new Set(entityTypeFromDb.map((et) => et.id))
-						const newEntityTypes = defaultEntityTypes.filter((et) => !existingIds.has(et.id))
-						entityTypeFromDb.push(...newEntityTypes)
-						console.log(
-							`💾 EntityType ${modelName}:${entityValue} found in defaults: ${defaultEntityTypes.length} results, ${newEntityTypes.length} unique added`
-						)
-					}
-				}
+				// Tenant isolation: no default tenant fallback
 			} catch (dbError) {
 				console.error(`Failed to fetch entityType ${modelName}:${entityValue} from database:`, dbError.message)
 				return null
@@ -701,35 +669,7 @@ const entityTypes = {
 					)
 				}
 
-				// Step 2: ALSO fetch from default codes (if different from user codes)
-				if (
-					defaults &&
-					defaults.orgCode &&
-					defaults.tenantCode &&
-					(defaults.tenantCode !== tenantCode || defaults.orgCode !== orgCode)
-				) {
-					console.log(
-						`💾 Entity types for model ${modelName} also fetching from defaults: tenant:${defaults.tenantCode}:org:${defaults.orgCode}`
-					)
-
-					const defaultFilter = {
-						status: 'ACTIVE',
-						organization_code: defaults.orgCode,
-						model_names: { [Op.contains]: [modelName] },
-					}
-					const defaultEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(defaultFilter, [
-						defaults.tenantCode,
-					])
-					if (defaultEntityTypes && defaultEntityTypes.length > 0) {
-						// Merge defaults, avoiding duplicates by ID
-						const existingIds = new Set(entityTypes.map((et) => et.id))
-						const newEntityTypes = defaultEntityTypes.filter((et) => !existingIds.has(et.id))
-						entityTypes.push(...newEntityTypes)
-						console.log(
-							`💾 Entity types for model ${modelName} found in defaults: ${defaultEntityTypes.length} results, ${newEntityTypes.length} unique added`
-						)
-					}
-				}
+				// Tenant isolation: no default tenant fallback
 			} catch (dbError) {
 				console.error(`Failed to fetch entity types for model ${modelName} from database:`, dbError.message)
 				return []
@@ -855,26 +795,7 @@ const forms = {
 				)
 
 				// Step 4: If not found with user codes and defaults exist, try with default codes
-				if (
-					!formFromDb &&
-					defaults &&
-					defaults.orgCode &&
-					defaults.tenantCode &&
-					(defaults.tenantCode !== tenantCode || defaults.orgCode !== orgCode)
-				) {
-					console.log(
-						`💾 Form ${type}:${subtype} not found with user codes, trying defaults: tenant:${defaults.tenantCode}:org:${defaults.orgCode}`
-					)
-
-					formFromDb = await formQueries.findOne(
-						{
-							type: type,
-							sub_type: subtype,
-							organization_code: defaults.orgCode,
-						},
-						defaults.tenantCode
-					)
-				}
+				// Tenant isolation: no default tenant fallback
 			} catch (dbError) {
 				console.error(`Failed to fetch form ${type}:${subtype} from database:`, dbError.message)
 				return null
@@ -1554,23 +1475,7 @@ const notificationTemplates = {
 				)
 
 				// If not found and defaults are different, try defaults
-				if (
-					!templateFromDb &&
-					defaults &&
-					defaults.orgCode &&
-					defaults.tenantCode &&
-					(defaults.tenantCode !== tenantCode || defaults.orgCode !== orgCode)
-				) {
-					templateFromDb = await notificationTemplateQueries.findOne(
-						{
-							code: templateCode,
-							organization_code: defaults.orgCode,
-							type: 'email',
-							status: 'active',
-						},
-						defaults.tenantCode
-					)
-				}
+				// Tenant isolation: no default tenant fallback
 
 				if (templateFromDb) {
 					console.log(

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -560,7 +560,12 @@ const entityTypes = {
 				}
 				if (entityValue) filter.value = entityValue
 
-				// Tenant isolation: no default tenant fallback
+				entityTypeFromDb = await entityTypeQueries.findUserEntityTypesAndEntities(filter, tenantCode)
+				if (entityTypeFromDb.length > 0) {
+					console.log(
+						`💾 EntityType ${modelName}:${entityValue} found in user tenant/org: ${entityTypeFromDb.length} results`
+					)
+				}
 			} catch (dbError) {
 				console.error(`Failed to fetch entityType ${modelName}:${entityValue} from database:`, dbError.message)
 				return null
@@ -639,8 +644,6 @@ const entityTypes = {
 						`💾 Entity types for model ${modelName} found in user tenant/org: ${userEntityTypes.length} results`
 					)
 				}
-
-				// Tenant isolation: no default tenant fallback
 			} catch (dbError) {
 				console.error(`Failed to fetch entity types for model ${modelName} from database:`, dbError.message)
 				return []
@@ -754,8 +757,11 @@ const forms = {
 					[tenantCode]
 				)
 
-				// Step 4: If not found with user codes and defaults exist, try with default codes
-				// Tenant isolation: no default tenant fallback
+				// Priority: user's org first, default org as fallback
+				formFromDb =
+					forms.find((f) => f.organization_code === orgCode) ||
+					forms.find((f) => f.organization_code === defaultOrgCode) ||
+					null
 			} catch (dbError) {
 				console.error(`Failed to fetch form ${type}:${subtype} from database:`, dbError.message)
 				return null

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -636,7 +636,7 @@ const entityTypes = {
 						organization_code: { [Op.in]: orgCandidates },
 						model_names: { [Op.contains]: [modelName] },
 					},
-					[tenantCode]
+					tenantCode
 				)
 				if (userEntityTypes && userEntityTypes.length > 0) {
 					entityTypes.push(...userEntityTypes)
@@ -754,7 +754,7 @@ const forms = {
 						sub_type: subtype,
 						organization_code: { [Op.in]: orgCandidates },
 					},
-					[tenantCode]
+					tenantCode
 				)
 
 				// Priority: user's org first, default org as fallback
@@ -1426,7 +1426,7 @@ const notificationTemplates = {
 					organization_code: orgCandidates,
 					tenant_code: tenantCode,
 					type: 'email',
-					status: 'active',
+					status: { [Op.iLike]: 'active' },
 				})
 
 				// Priority: user's org first, default org as fallback

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -550,24 +550,22 @@ const entityTypes = {
 
 			let entityTypeFromDb = []
 			try {
-				// Step 1: Fetch from user tenant and org codes
-				const userFilter = {
+				const defaultOrgCode = process.env.DEFAULT_ORGANISATION_CODE
+				const orgCandidates = [...new Set([orgCode, defaultOrgCode].filter(Boolean))]
+
+				const filter = {
 					status: 'ACTIVE',
-					organization_code: orgCode,
+					organization_code: { [Op.in]: orgCandidates },
 					model_names: { [Op.contains]: modelName },
 				}
-				if (entityValue) {
-					userFilter.value = entityValue
-				}
-				const userEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, tenantCode)
-				if (userEntityTypes && userEntityTypes.length > 0) {
-					entityTypeFromDb.push(...userEntityTypes)
+				if (entityValue) filter.value = entityValue
+
+				entityTypeFromDb = await entityTypeQueries.findUserEntityTypesAndEntities(filter, tenantCode)
+				if (entityTypeFromDb.length > 0) {
 					console.log(
-						`💾 EntityType ${modelName}:${entityValue} found in user tenant/org: ${userEntityTypes.length} results`
+						`💾 EntityType ${modelName}:${entityValue} found in user tenant/org: ${entityTypeFromDb.length} results`
 					)
 				}
-
-				// Tenant isolation: no default tenant fallback
 			} catch (dbError) {
 				console.error(`Failed to fetch entityType ${modelName}:${entityValue} from database:`, dbError.message)
 				return null
@@ -629,21 +627,23 @@ const entityTypes = {
 			// Get defaults internally for database query
 			let entityTypes = []
 			try {
-				// Step 1: Fetch from user tenant and org codes
-				const userFilter = {
-					status: 'ACTIVE',
-					organization_code: orgCode,
-					model_names: { [Op.contains]: [modelName] },
-				}
-				const userEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, [tenantCode])
+				const defaultOrgCode = process.env.DEFAULT_ORGANISATION_CODE
+				const orgCandidates = [...new Set([orgCode, defaultOrgCode].filter(Boolean))]
+
+				const userEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(
+					{
+						status: 'ACTIVE',
+						organization_code: { [Op.in]: orgCandidates },
+						model_names: { [Op.contains]: [modelName] },
+					},
+					[tenantCode]
+				)
 				if (userEntityTypes && userEntityTypes.length > 0) {
 					entityTypes.push(...userEntityTypes)
 					console.log(
 						`💾 Entity types for model ${modelName} found in user tenant/org: ${userEntityTypes.length} results`
 					)
 				}
-
-				// Tenant isolation: no default tenant fallback
 			} catch (dbError) {
 				console.error(`Failed to fetch entity types for model ${modelName} from database:`, dbError.message)
 				return []
@@ -745,18 +745,23 @@ const forms = {
 
 			let formFromDb = null
 			try {
-				// First try with user tenant and org codes
-				formFromDb = await formQueries.findOne(
+				const defaultOrgCode = process.env.DEFAULT_ORGANISATION_CODE
+				const orgCandidates = [...new Set([orgCode, defaultOrgCode].filter(Boolean))]
+
+				const forms = await formQueries.findFormsByFilter(
 					{
-						type: type,
+						type,
 						sub_type: subtype,
-						organization_code: orgCode,
+						organization_code: { [Op.in]: orgCandidates },
 					},
-					tenantCode
+					[tenantCode]
 				)
 
-				// Step 4: If not found with user codes and defaults exist, try with default codes
-				// Tenant isolation: no default tenant fallback
+				// Priority: user's org first, default org as fallback
+				formFromDb =
+					forms.find((f) => f.organization_code === orgCode) ||
+					forms.find((f) => f.organization_code === defaultOrgCode) ||
+					null
 			} catch (dbError) {
 				console.error(`Failed to fetch form ${type}:${subtype} from database:`, dbError.message)
 				return null
@@ -1407,23 +1412,28 @@ const notificationTemplates = {
 				return cachedTemplate
 			}
 
-			// Step 2: Cache miss - query database with user codes
+			// Step 2: Cache miss - query database
+			// Fetch both user org and default org templates in one query, then prioritize
 
 			let templateFromDb = null
 			try {
-				// Try user tenant/org first
-				templateFromDb = await notificationTemplateQueries.findOne(
-					{
-						code: templateCode,
-						organization_code: orgCode,
-						type: 'email',
-						status: 'active',
-					},
-					tenantCode
-				)
+				const defaultOrgCode = process.env.DEFAULT_ORGANISATION_CODE
+				const orgCandidates = [orgCode]
+				if (defaultOrgCode && defaultOrgCode !== orgCode) orgCandidates.push(defaultOrgCode)
 
-				// If not found and defaults are different, try defaults
-				// Tenant isolation: no default tenant fallback
+				const templates = await notificationTemplateQueries.findTemplatesByFilter({
+					code: templateCode,
+					organization_code: orgCandidates,
+					tenant_code: tenantCode,
+					type: 'email',
+					status: 'active',
+				})
+
+				// Priority: user's org first, default org as fallback
+				templateFromDb =
+					templates.find((t) => t.organization_code === orgCode) ||
+					templates.find((t) => t.organization_code === defaultOrgCode) ||
+					null
 
 				if (templateFromDb) {
 					console.log(

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -13,6 +13,7 @@ const notificationTemplateQueries = require('@database/queries/notificationTempl
 const sessionQueries = require('@database/queries/sessions')
 const permissionQueries = require('@database/queries/permissions')
 const rolePermissionMappingQueries = require('@database/queries/role-permission-mapping')
+const { getDefaults } = require('@helpers/getDefaultOrgId')
 const kafkaCommunication = require('@generics/kafka-communication')
 // Removed SessionsHelper import to avoid circular dependency
 const formQueries = require('@database/queries/form')
@@ -1412,28 +1413,28 @@ const notificationTemplates = {
 				return cachedTemplate
 			}
 
-			// Step 2: Cache miss - query database
-			// Fetch both user org and default org templates in one query, then prioritize
+			// Step 2: Get defaults internally for database query
+			let defaults = null
+			try {
+				defaults = await getDefaults()
+			} catch (error) {
+				console.error('Failed to get defaults for notification template cache:', error.message)
+				// Fallback defaults from environment variables
+				defaults = {
+					orgCode: process.env.DEFAULT_ORGANISATION_CODE || 'default_code',
+					tenantCode: process.env.DEFAULT_TENANT_CODE || 'default',
+				}
+			}
 
+			// Step 3: Cache miss - query database with header/footer injection
+			// Uses findOneEmailTemplate so email_header (logo) and email_footer are composed into body
 			let templateFromDb = null
 			try {
-				const defaultOrgCode = process.env.DEFAULT_ORGANISATION_CODE
-				const orgCandidates = [orgCode]
-				if (defaultOrgCode && defaultOrgCode !== orgCode) orgCandidates.push(defaultOrgCode)
-
-				const templates = await notificationTemplateQueries.findTemplatesByFilter({
-					code: templateCode,
-					organization_code: orgCandidates,
-					tenant_code: tenantCode,
-					type: 'email',
-					status: { [Op.iLike]: 'active' },
-				})
-
-				// Priority: user's org first, default org as fallback
-				templateFromDb =
-					templates.find((t) => t.organization_code === orgCode) ||
-					templates.find((t) => t.organization_code === defaultOrgCode) ||
-					null
+				templateFromDb = await notificationTemplateQueries.findOneEmailTemplate(
+					templateCode,
+					[orgCode, defaults.orgCode],
+					tenantCode
+				)
 
 				if (templateFromDb) {
 					console.log(

--- a/src/generics/materializedViews.js
+++ b/src/generics/materializedViews.js
@@ -371,7 +371,7 @@ const getAllowFilteringEntityTypes = async (tenantCode) => {
 		// but support tenant-specific customizations through tenant code combination
 		const entities = await entityTypeQueries.findAllEntityTypes(
 			defaults.orgCode, // Use default org code (global configurations)
-			{ [Op.in]: [tenantCode, defaults.tenantCode] }, // Combination of tenant codes
+			tenantCode, // Tenant isolation: only current tenant
 			['id', 'value', 'label', 'data_type', 'organization_id', 'has_entities', 'model_names'],
 			{
 				allow_filtering: true,

--- a/src/generics/utils.js
+++ b/src/generics/utils.js
@@ -732,6 +732,7 @@ function convertEntitiesForFilter(entityTypes) {
 			value: entityType.value,
 			parent_id: entityType.parent_id,
 			organization_id: entityType.organization_id,
+			organization_code: entityType.organization_code,
 			entities: entityType.entities || [],
 		}
 

--- a/src/helpers/defaultRules.js
+++ b/src/helpers/defaultRules.js
@@ -228,7 +228,7 @@ exports.validateDefaultRulesFilter = async function validateDefaultRulesFilter({
 	try {
 		const defaults = await getDefaults()
 		let orgCodes = { [Op.in]: [requesterOrganizationCode, defaults.orgCode] }
-		let tenantCodes = { [Op.in]: [tenantCode, defaults.tenantCode] }
+		let tenantCodes = tenantCode
 		const [userDetails, defaultRules] = await Promise.all([
 			getUserDetailsFromCache(requesterId, isAMentor(roles), tenantCode, requesterOrganizationCode),
 			defaultRuleQueries.findAll({ type: ruleType, organization_code: orgCodes }, tenantCodes),

--- a/src/helpers/defaultRules.js
+++ b/src/helpers/defaultRules.js
@@ -228,10 +228,9 @@ exports.validateDefaultRulesFilter = async function validateDefaultRulesFilter({
 	try {
 		const defaults = await getDefaults()
 		let orgCodes = { [Op.in]: [requesterOrganizationCode, defaults.orgCode] }
-		let tenantCodes = tenantCode
 		const [userDetails, defaultRules] = await Promise.all([
 			getUserDetailsFromCache(requesterId, isAMentor(roles), tenantCode, requesterOrganizationCode),
-			defaultRuleQueries.findAll({ type: ruleType, organization_code: orgCodes }, tenantCodes),
+			defaultRuleQueries.findAll({ type: ruleType, organization_code: orgCodes }, tenantCode),
 		])
 
 		const validConfigs = getValidConfigs(defaultRules || [], roles)

--- a/src/helpers/entityType.js
+++ b/src/helpers/entityType.js
@@ -50,11 +50,7 @@ module.exports = class UserHelper {
 					responseCode: 'CLIENT_ERROR',
 				})
 			// Fallback to DB if no cached data found
-			const entities = await entityTypeQueries.findAllEntityTypes(
-				orgCodes,
-				{ [Op.in]: [defaults.tenantCode, tenantCode] },
-				attributes
-			)
+			const entities = await entityTypeQueries.findAllEntityTypes(orgCodes, tenantCode, attributes)
 			return entities || null
 		} catch (err) {
 			return null

--- a/src/helpers/entityTypeCache.js
+++ b/src/helpers/entityTypeCache.js
@@ -40,28 +40,7 @@ async function getEntityTypesAndEntitiesWithCache(originalFilter, tenantCode, or
 			)
 			let dbResult = userResults ? [...userResults] : []
 
-			// Step 2: ALSO ALWAYS fetch from default codes (if different from user codes)
-			if (
-				defaults &&
-				defaults.orgCode &&
-				defaults.tenantCode &&
-				(defaults.tenantCode !== tenantCode || defaults.orgCode !== orgCode)
-			) {
-				let defaultFilter = {
-					...originalFilter,
-					organization_code: defaults.orgCode,
-				}
-				const defaultResults = await entityTypeQueries.findUserEntityTypesAndEntities(defaultFilter, [
-					defaults.tenantCode,
-				])
-				if (defaultResults && defaultResults.length > 0) {
-					// Merge defaults, avoiding duplicates by ID
-					const existingIds = new Set(dbResult.map((et) => et.id))
-					const newEntityTypes = defaultResults.filter((et) => !existingIds.has(et.id))
-					dbResult.push(...newEntityTypes)
-				}
-			}
-
+			// Tenant isolation: no default tenant fallback
 			return dbResult || []
 		}
 
@@ -144,24 +123,7 @@ async function getEntityTypesAndEntitiesWithCache(originalFilter, tenantCode, or
 				Array.isArray(tenantCode) ? tenantCode : [tenantCode]
 			)
 
-			// If not found with user codes and defaults exist, try with default codes
-			if (
-				(!dbResult || dbResult.length === 0) &&
-				defaults &&
-				defaults.orgCode &&
-				defaults.tenantCode &&
-				(defaults.tenantCode !== tenantCode || defaults.orgCode !== orgCode)
-			) {
-				console.log(
-					`💾 EntityTypes not found with user codes, trying defaults: tenant:${defaults.tenantCode}:org:${defaults.orgCode}`
-				)
-
-				let defaultFilter = {
-					...originalFilter,
-					organization_code: defaults.orgCode,
-				}
-				dbResult = await entityTypeQueries.findUserEntityTypesAndEntities(defaultFilter, [defaults.tenantCode])
-			}
+			// Tenant isolation: no default tenant fallback
 		} catch (dbError) {
 			console.error(`Failed to fetch entity types from database:`, dbError.message)
 			return []
@@ -300,27 +262,7 @@ async function getEntityTypesAndEntitiesForModel(modelName, tenantCode, orgCode,
 				allEntityTypes.push(...userEntityTypes)
 			}
 
-			// Step 2: ALSO ALWAYS fetch from default codes (if different from user codes)
-			if (
-				defaults.orgCode &&
-				defaults.tenantCode &&
-				(defaults.tenantCode !== tenantCode || defaults.orgCode !== orgCode)
-			) {
-				const defaultFilter = {
-					status: 'ACTIVE',
-					organization_code: defaults.orgCode,
-					model_names: { [Op.contains]: [modelName] },
-				}
-				const defaultEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(defaultFilter, [
-					defaults.tenantCode,
-				])
-				if (defaultEntityTypes && defaultEntityTypes.length > 0) {
-					// Merge defaults, avoiding duplicates by ID
-					const existingIds = new Set(allEntityTypes.map((et) => et.id))
-					const newEntityTypes = defaultEntityTypes.filter((et) => !existingIds.has(et.id))
-					allEntityTypes.push(...newEntityTypes)
-				}
-			}
+			// Tenant isolation: no default tenant fallback
 		} catch (dbError) {
 			console.error(`Failed to fetch entity types for model ${modelName} from database:`, dbError.message)
 			return []
@@ -433,23 +375,7 @@ async function getEntityTypeByValue(modelName, entityValue, tenantCode, orgCode)
 		)
 		found = entityTypes.length > 0 ? entityTypes[0] : null
 
-		// If not found with user codes and defaults exist, try with default codes
-		if (
-			!found &&
-			defaults &&
-			defaults.orgCode &&
-			defaults.tenantCode &&
-			(defaults.tenantCode !== tenantCode || defaults.orgCode !== orgCode)
-		) {
-			const defaultFilter = {
-				status: 'ACTIVE',
-				value: entityValue,
-				organization_code: defaults.orgCode,
-				model_names: { [Op.contains]: [modelName] },
-			}
-			entityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(defaultFilter, [defaults.tenantCode])
-			found = entityTypes.length > 0 ? entityTypes[0] : null
-		}
+		// Tenant isolation: no default tenant fallback
 	} catch (dbError) {
 		console.error(`Failed to fetch entity type ${modelName}:${entityValue} from database:`, dbError.message)
 		return null

--- a/src/helpers/entityTypeCache.js
+++ b/src/helpers/entityTypeCache.js
@@ -34,13 +34,9 @@ async function getEntityTypesAndEntitiesWithCache(originalFilter, tenantCode, or
 				...originalFilter,
 				organization_code: orgCode,
 			}
-			const userResults = await entityTypeQueries.findUserEntityTypesAndEntities(
-				userFilter,
-				Array.isArray(tenantCode) ? tenantCode : [tenantCode]
-			)
+			const userResults = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, tenantCode)
 			let dbResult = userResults ? [...userResults] : []
 
-			// Tenant isolation: no default tenant fallback
 			return dbResult || []
 		}
 
@@ -118,12 +114,7 @@ async function getEntityTypesAndEntitiesWithCache(originalFilter, tenantCode, or
 				...originalFilter,
 				organization_code: orgCode,
 			}
-			dbResult = await entityTypeQueries.findUserEntityTypesAndEntities(
-				userFilter,
-				Array.isArray(tenantCode) ? tenantCode : [tenantCode]
-			)
-
-			// Tenant isolation: no default tenant fallback
+			dbResult = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, tenantCode)
 		} catch (dbError) {
 			console.error(`Failed to fetch entity types from database:`, dbError.message)
 			return []
@@ -156,10 +147,7 @@ async function getEntityTypesAndEntitiesWithCache(originalFilter, tenantCode, or
 				...originalFilter,
 				organization_code: orgCode,
 			}
-			return await entityTypeQueries.findUserEntityTypesAndEntities(
-				userFilter,
-				Array.isArray(tenantCode) ? tenantCode : [tenantCode]
-			)
+			return await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, tenantCode)
 		} catch (fallbackError) {
 			console.error(`❌ Fallback database query also failed:`, fallbackError)
 			return []
@@ -256,13 +244,10 @@ async function getEntityTypesAndEntitiesForModel(modelName, tenantCode, orgCode,
 				model_names: { [Op.contains]: [modelName] },
 			}
 			// Handle both array and single value for tenantCode
-			const tenantCodesArray = Array.isArray(tenantCode) ? tenantCode : [tenantCode]
-			const userEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, tenantCodesArray)
+			const userEntityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, tenantCode)
 			if (userEntityTypes && userEntityTypes.length > 0) {
 				allEntityTypes.push(...userEntityTypes)
 			}
-
-			// Tenant isolation: no default tenant fallback
 		} catch (dbError) {
 			console.error(`Failed to fetch entity types for model ${modelName} from database:`, dbError.message)
 			return []
@@ -369,13 +354,8 @@ async function getEntityTypeByValue(modelName, entityValue, tenantCode, orgCode)
 			organization_code: orgCode,
 			model_names: { [Op.contains]: [modelName] },
 		}
-		let entityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(
-			userFilter,
-			Array.isArray(tenantCode) ? tenantCode : [tenantCode]
-		)
+		let entityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(userFilter, tenantCode)
 		found = entityTypes.length > 0 ? entityTypes[0] : null
-
-		// Tenant isolation: no default tenant fallback
 	} catch (dbError) {
 		console.error(`Failed to fetch entity type ${modelName}:${entityValue} from database:`, dbError.message)
 		return null

--- a/src/helpers/getEnrolledMentees.js
+++ b/src/helpers/getEnrolledMentees.js
@@ -76,7 +76,7 @@ exports.getEnrolledMentees = async (sessionId, queryParams, tenantCode) => {
 			[modelName],
 			'organization_id',
 			[],
-			[tenantCode]
+			tenantCode
 		)
 
 		// Check if processing actually returned processed data or error

--- a/src/helpers/getOrgIdAndEntityTypewithEntitiesBasedOnPolicy.js
+++ b/src/helpers/getOrgIdAndEntityTypewithEntitiesBasedOnPolicy.js
@@ -241,8 +241,7 @@ module.exports = class OrganizationAndEntityTypePolicyHelper {
 		defaultOrgCode = '',
 		modelName,
 		filter = {},
-		tenantCodes,
-		defaultTenantCode = ''
+		tenantCode
 	) {
 		try {
 			filter.status = common.ACTIVE_STATUS
@@ -270,9 +269,6 @@ module.exports = class OrganizationAndEntityTypePolicyHelper {
 				filter.model_names = { [Op.contains]: Array.isArray(modelName) ? modelName : [modelName] }
 			}
 			//fetch entity types and entities
-			// Handle both array and string cases for tenantCodes
-			const tenantCodeArray = Array.isArray(tenantCodes) ? tenantCodes : [tenantCodes]
-			const finalTenantCodes = defaultTenantCode ? [...tenantCodeArray, defaultTenantCode] : tenantCodeArray
 
 			// Use cache for model-based queries since this query has core fields only
 			let entityTypesWithEntities
@@ -282,7 +278,7 @@ module.exports = class OrganizationAndEntityTypePolicyHelper {
 				try {
 					entityTypesWithEntities = await entityTypeCache.getEntityTypesAndEntitiesForModel(
 						modelName,
-						finalTenantCodes,
+						tenantCode,
 						filter.organization_code[Op.in],
 						{
 							allow_filtering: filter.allow_filtering,
@@ -291,17 +287,11 @@ module.exports = class OrganizationAndEntityTypePolicyHelper {
 					)
 				} catch (cacheError) {
 					// Fallback to direct database query
-					entityTypesWithEntities = await entityTypeQueries.findUserEntityTypesAndEntities(
-						filter,
-						finalTenantCodes
-					)
+					entityTypesWithEntities = await entityTypeQueries.findUserEntityTypesAndEntities(filter, tenantCode)
 				}
 			} else {
 				// Query has specific entity values or other non-core filters - use direct query
-				entityTypesWithEntities = await entityTypeQueries.findUserEntityTypesAndEntities(
-					filter,
-					finalTenantCodes
-				)
+				entityTypesWithEntities = await entityTypeQueries.findUserEntityTypesAndEntities(filter, tenantCode)
 			}
 			return {
 				success: true,

--- a/src/helpers/search.js
+++ b/src/helpers/search.js
@@ -240,7 +240,7 @@ async function getEntityTypeFilter(modelName, config, search, searchOn, tenantCo
 		entity_type_id: entityTypeIds,
 	}
 
-	const entities = await entityQueries.findAllEntities(filter, { [Op.in]: [tenantCode, defaults.tenantCode] })
+	const entities = await entityQueries.findAllEntities(filter, tenantCode)
 
 	if (entities.length == 0) {
 		return false

--- a/src/middlewares/authenticator.js
+++ b/src/middlewares/authenticator.js
@@ -130,6 +130,11 @@ module.exports = async function (req, res, next) {
 				? req.decodedToken?.organization_id?.toString()
 				: req.decodedToken?.organization_id
 
+		if (!req.decodedToken.tenant_code && process.env.DEFAULT_TENANT_CODE) {
+			req.decodedToken.tenant_code = process.env.DEFAULT_TENANT_CODE
+			console.log('tenant_code was missing, set from DEFAULT_TENANT_CODE:', req.decodedToken.tenant_code)
+		}
+
 		if (!req.decodedToken[organizationKey]) {
 			throw createUnauthorizedResponse()
 		}

--- a/src/middlewares/authenticator.js
+++ b/src/middlewares/authenticator.js
@@ -130,11 +130,6 @@ module.exports = async function (req, res, next) {
 				? req.decodedToken?.organization_id?.toString()
 				: req.decodedToken?.organization_id
 
-		if (!req.decodedToken.tenant_code && process.env.DEFAULT_TENANT_CODE) {
-			req.decodedToken.tenant_code = process.env.DEFAULT_TENANT_CODE
-			console.log('tenant_code was missing, set from DEFAULT_TENANT_CODE:', req.decodedToken.tenant_code)
-		}
-
 		if (!req.decodedToken[organizationKey]) {
 			throw createUnauthorizedResponse()
 		}

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -316,7 +316,7 @@ module.exports = class AdminService {
 
 					if (connectedMentees.length > 0) {
 						const orgCodes = [userInfo.organization_code, defaults.orgCode].filter(Boolean)
-						const tenantCodes = [userTenantCode, defaults.tenantCode].filter(Boolean)
+						const tenantCodes = [userTenantCode].filter(Boolean)
 						result.isMenteeNotifiedAboutMentorDeletion = await this.notifyMenteesAboutMentorDeletion(
 							connectedMentees,
 							userInfo.name || 'Mentor',
@@ -340,7 +340,7 @@ module.exports = class AdminService {
 				// Notify connected mentors about mentee deletion
 				if (connectedMentors.length > 0 && !isMentor) {
 					const orgCodes = [userInfo.organization_code, defaults.orgCode].filter(Boolean)
-					const tenantCodes = [userTenantCode, defaults.tenantCode].filter(Boolean)
+					const tenantCodes = [userTenantCode].filter(Boolean)
 
 					result.isMentorNotifiedAboutMenteeDeletion = await this.notifyMentorsAboutMenteeDeletion(
 						connectedMentors,
@@ -400,7 +400,7 @@ module.exports = class AdminService {
 
 				// Use both user's codes and defaults for notification templates
 				const orgCodes = [organizationCode, defaults.orgCode].filter(Boolean)
-				const tenantCodes = [userTenantCode, defaults.tenantCode].filter(Boolean)
+				const tenantCodes = [userTenantCode].filter(Boolean)
 
 				if (requestedSessions.length > 0) {
 					result.isRequestedSessionMentorNotified = await this.NotifySessionRequestedUsers(
@@ -490,7 +490,7 @@ module.exports = class AdminService {
 			try {
 				if (privateSessions.length > 0) {
 					const orgCodes = [userInfo.organization_code, defaults.orgCode].filter(Boolean)
-					const tenantCodes = [userTenantCode, defaults.tenantCode].filter(Boolean)
+					const tenantCodes = [userTenantCode].filter(Boolean)
 
 					result.isPrivateSessionsCancelled = await this.notifyAndCancelPrivateSessions(
 						privateSessions,
@@ -1204,7 +1204,7 @@ module.exports = class AdminService {
 			const defaults = await getDefaults()
 			const userOrgCode = userInfo.organization_code || ''
 			const orgCodes = [userOrgCode, defaults.orgCode].filter(Boolean)
-			const tenantCodes = [tenantCode, defaults.tenantCode].filter(Boolean)
+			const tenantCodes = [tenantCode].filter(Boolean)
 
 			// 1. Get upcoming private sessions where deleted mentee was enrolled
 			const upcomingSessions = await sessionQueries.getUpcomingSessionsOfMentee(
@@ -1236,7 +1236,7 @@ module.exports = class AdminService {
 			const defaults = await getDefaults()
 			const userOrgCode = mentorInfo.organization_code
 			const orgCodes = [userOrgCode, defaults.orgCode].filter(Boolean)
-			const tenantCodes = [tenantCode, defaults.tenantCode].filter(Boolean)
+			const tenantCodes = [tenantCode].filter(Boolean)
 
 			// 2. Handle session requests - auto-reject pending requests
 			const pendingSessionRequests = await this.getPendingSessionRequestsForMentor(mentorUserId, tenantCode)

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -36,7 +36,7 @@ class NotificationHelper {
 		orgCode,
 		templateData = {},
 		subjectData = {},
-		tenantCodes,
+		tenantCode,
 	}) {
 		try {
 			if (!templateCode || !recipients?.length) {
@@ -45,11 +45,10 @@ class NotificationHelper {
 			}
 
 			// Handle arrays: extract first value (user codes), cacheHelper will fallback to defaults if not found
-			const userTenantCode = Array.isArray(tenantCodes) ? tenantCodes[0] : tenantCodes
 			const userOrgCode = Array.isArray(orgCode) ? orgCode[0] : orgCode
 
 			// cacheHelper.get will automatically search user codes first, then defaults when cache is disabled
-			const template = await cacheHelper.notificationTemplates.get(userTenantCode, userOrgCode, templateCode)
+			const template = await cacheHelper.notificationTemplates.get(tenantCode, userOrgCode, templateCode)
 			if (!template) {
 				console.log(`Template ${templateCode} not found`)
 				return true
@@ -87,17 +86,16 @@ class NotificationHelper {
 		addionalData = {},
 		tenantCode,
 		orgCodes,
-		tenantCodes,
 	}) {
 		try {
 			if (!sessions?.length || !templateCode) return true
 
 			// Handle arrays: extract first value (user codes), cacheHelper will fallback to defaults if not found
-			const userTenantCode = Array.isArray(tenantCode) ? tenantCode[0] : tenantCode
+			const userTenantCode = tenantCode
 			const userOrgCode = Array.isArray(orgCode) ? orgCode[0] : orgCode
 
 			// cacheHelper.get will automatically search user codes first, then defaults when cache is disabled
-			const template = await cacheHelper.notificationTemplates.get(userTenantCode, userOrgCode, templateCode)
+			const template = await cacheHelper.notificationTemplates.get(tenantCode, userOrgCode, templateCode)
 			if (!template) {
 				console.log(`Template ${templateCode} not found`)
 				return true
@@ -315,12 +313,11 @@ module.exports = class AdminService {
 
 					if (connectedMentees.length > 0) {
 						const orgCodes = [userInfo.organization_code, defaults.orgCode].filter(Boolean)
-						const tenantCodes = [userTenantCode].filter(Boolean)
 						result.isMenteeNotifiedAboutMentorDeletion = await this.notifyMenteesAboutMentorDeletion(
 							connectedMentees,
 							userInfo.name || 'Mentor',
 							orgCodes,
-							tenantCodes
+							userTenantCode
 						)
 					} else {
 						result.isMenteeNotifiedAboutMentorDeletion = true
@@ -339,13 +336,12 @@ module.exports = class AdminService {
 				// Notify connected mentors about mentee deletion
 				if (connectedMentors.length > 0 && !isMentor) {
 					const orgCodes = [userInfo.organization_code, defaults.orgCode].filter(Boolean)
-					const tenantCodes = [userTenantCode].filter(Boolean)
 
 					result.isMentorNotifiedAboutMenteeDeletion = await this.notifyMentorsAboutMenteeDeletion(
 						connectedMentors,
 						userInfo.name || 'User',
 						orgCodes,
-						tenantCodes
+						userTenantCode
 					)
 				} else {
 					result.isMentorNotifiedAboutMenteeDeletion = true
@@ -399,7 +395,6 @@ module.exports = class AdminService {
 
 				// Use both user's codes and defaults for notification templates
 				const orgCodes = [organizationCode, defaults.orgCode].filter(Boolean)
-				const tenantCodes = [userTenantCode].filter(Boolean)
 
 				if (requestedSessions.length > 0) {
 					result.isRequestedSessionMentorNotified = await this.NotifySessionRequestedUsers(
@@ -407,10 +402,10 @@ module.exports = class AdminService {
 						false,
 						true,
 						orgCodes,
-						tenantCodes,
+						userTenantCode,
 						organizationCode,
 						userTenantCode
-					) // (sessionsDetails, received, sent, orgCodes, tenantCodes)
+					) // (sessionsDetails, received, sent, orgCodes, tenantCode)
 				}
 
 				if (isMentor && receivedSessions.length > 0) {
@@ -419,10 +414,10 @@ module.exports = class AdminService {
 						true,
 						false,
 						orgCodes,
-						tenantCodes,
+						userTenantCode,
 						organizationCode,
 						userTenantCode
-					) // (sessionsDetails, received, sent, orgCodes, tenantCodes)
+					) // (sessionsDetails, received, sent, orgCodes, tenantCode)
 				}
 			}
 
@@ -489,12 +484,11 @@ module.exports = class AdminService {
 			try {
 				if (privateSessions.length > 0) {
 					const orgCodes = [userInfo.organization_code, defaults.orgCode].filter(Boolean)
-					const tenantCodes = [userTenantCode].filter(Boolean)
 
 					result.isPrivateSessionsCancelled = await this.notifyAndCancelPrivateSessions(
 						privateSessions,
 						orgCodes,
-						tenantCodes
+						userTenantCode
 					)
 				} else {
 					result.isPrivateSessionsCancelled = true
@@ -634,7 +628,6 @@ module.exports = class AdminService {
 		received = false,
 		sent = false,
 		orgCodes,
-		tenantCodes,
 		orgCode,
 		tenantCode
 	) {
@@ -656,7 +649,6 @@ module.exports = class AdminService {
 				addionalData: { nameOfTheSession: '{sessionName}' },
 				tenantCode,
 				orgCodes,
-				tenantCodes,
 			})
 		} catch (error) {
 			console.error('An error occurred in NotifySessionRequestedUsers:', error)
@@ -664,17 +656,10 @@ module.exports = class AdminService {
 		}
 	}
 
-	static async unenrollAndNotifySessionAttendees(
-		removedSessionsDetail,
-		orgCodes = [],
-		tenantCodes = [],
-		tenantCode,
-		orgCode
-	) {
+	static async unenrollAndNotifySessionAttendees(removedSessionsDetail, orgCodes = [], tenantCode, orgCode) {
 		try {
 			// Use first organization and tenant codes for notification
 			const orgsCode = Array.isArray(orgCodes) ? orgCodes[0] : orgCodes
-			const tenantsCode = Array.isArray(tenantCodes) ? tenantCodes[0] : tenantCodes
 
 			// Send notifications using generic helper
 			const notificationResult = await NotificationHelper.sendSessionNotification({
@@ -685,7 +670,6 @@ module.exports = class AdminService {
 				addionalData: { nameOfTheSession: '{sessionName}' },
 				tenantCode,
 				orgsCode,
-				tenantsCode,
 			})
 
 			// Unenroll attendees from sessions
@@ -885,7 +869,7 @@ module.exports = class AdminService {
 		}
 	}
 
-	static async notifyAndCancelPrivateSessions(privateSessions, orgCodes, tenantCodes) {
+	static async notifyAndCancelPrivateSessions(privateSessions, orgCodes, tenantCode) {
 		const transaction = await sequelize.transaction()
 		try {
 			let allNotificationsSent = true
@@ -894,7 +878,7 @@ module.exports = class AdminService {
 				// Check if this is a one-on-one session (only one attendee)
 				const attendeeCount = await sessionAttendeesQueries.getCount({
 					session_id: session.id,
-					tenant_code: tenantCodes[0], // Use primary tenant for database query
+					tenant_code: tenantCode, // Use primary tenant for database query
 				})
 
 				if (attendeeCount === 1 && session.mentor_id == session.created_by) {
@@ -903,7 +887,7 @@ module.exports = class AdminService {
 						session.mentor_id,
 						session,
 						orgCodes,
-						tenantCodes
+						tenantCode
 					)
 
 					if (!notificationSent) {
@@ -913,7 +897,7 @@ module.exports = class AdminService {
 					// Mark session as cancelled/deleted
 					await sessionQueries.updateRecords(
 						{ deleted_at: new Date() },
-						{ where: { id: session.id, tenant_code: tenantCodes[0] } }, // Use primary tenant for database query
+						{ where: { id: session.id, tenant_code: tenantCode } }, // Use primary tenant for database query
 						transaction
 					)
 					// sessionOwnership deletion removed - no longer needed with direct Session mentor_id management
@@ -1127,14 +1111,14 @@ module.exports = class AdminService {
 		}
 	}
 
-	static async notifyMentorsAboutMenteeDeletion(mentors, menteeName, orgCodes, tenantCodes) {
+	static async notifyMentorsAboutMenteeDeletion(mentors, menteeName, orgCodes, tenantCode) {
 		return await NotificationHelper.sendGenericNotification({
 			recipients: mentors,
 			templateCode: process.env.MENTEE_DELETION_NOTIFICATION_EMAIL_TEMPLATE,
 			orgCode: orgCodes,
 			templateData: { menteeName },
 			subjectData: { menteeName },
-			tenantCodes,
+			tenantCode,
 		})
 	}
 
@@ -1170,13 +1154,13 @@ module.exports = class AdminService {
 		}
 	}
 
-	static async notifyMentorAboutPrivateSessionCancellation(mentorId, sessionDetails, orgCodes, tenantCodes) {
+	static async notifyMentorAboutPrivateSessionCancellation(mentorId, sessionDetails, orgCodes, tenantCode) {
 		try {
 			const mentorDetails = await mentorQueries.getMentorExtension(
 				mentorId,
 				['name', 'email'],
 				true,
-				tenantCodes[0] // Use primary tenant for database query
+				tenantCode // Use primary tenant for database query
 			)
 
 			const sessionDateTime = moment.unix(sessionDetails.start_date)
@@ -1191,7 +1175,7 @@ module.exports = class AdminService {
 					sessionTime: sessionDateTime.format('hh:mm A'),
 				},
 				subjectData: { sessionName: sessionDetails.title },
-				tenantCodes,
+				tenantCode,
 			})
 		} catch (error) {
 			console.error('Error notifying mentor about private session cancellation:', error)
@@ -1205,7 +1189,6 @@ module.exports = class AdminService {
 			const defaults = await getDefaults()
 			const userOrgCode = userInfo.organization_code || ''
 			const orgCodes = [userOrgCode, defaults.orgCode].filter(Boolean)
-			const tenantCodes = [tenantCode].filter(Boolean)
 
 			// 1. Get upcoming private sessions where deleted mentee was enrolled
 			const upcomingSessions = await sessionQueries.getUpcomingSessionsOfMentee(
@@ -1219,7 +1202,7 @@ module.exports = class AdminService {
 					upcomingSessions,
 					userInfo.name || 'User',
 					orgCodes,
-					tenantCodes
+					tenantCode
 				)
 			} else {
 				result.isSessionManagerNotified = true
@@ -1237,7 +1220,6 @@ module.exports = class AdminService {
 			const defaults = await getDefaults()
 			const userOrgCode = mentorInfo.organization_code
 			const orgCodes = [userOrgCode, defaults.orgCode].filter(Boolean)
-			const tenantCodes = [tenantCode].filter(Boolean)
 
 			// 2. Handle session requests - auto-reject pending requests
 			const pendingSessionRequests = await this.getPendingSessionRequestsForMentor(mentorUserId, tenantCode)
@@ -1246,7 +1228,7 @@ module.exports = class AdminService {
 				result.isSessionRequestsRejected = await this.rejectSessionRequestsDueToMentorDeletion(
 					pendingSessionRequests,
 					orgCodes,
-					tenantCodes
+					tenantCode
 				)
 			} else {
 				result.isSessionRequestsRejected = true
@@ -1261,7 +1243,7 @@ module.exports = class AdminService {
 					upcomingSessions,
 					mentorInfo.name || 'Mentor',
 					orgCodes,
-					tenantCodes
+					tenantCode
 				)
 			} else {
 				result.isSessionManagerNotified = true
@@ -1284,7 +1266,6 @@ module.exports = class AdminService {
 			result.isAttendeesNotified = await this.unenrollAndNotifySessionAttendees(
 				removedSessionsDetail,
 				orgCodes,
-				tenantCodes,
 				tenantCode,
 				userOrgCode
 			)
@@ -1295,7 +1276,7 @@ module.exports = class AdminService {
 				userOrgCode,
 				tenantCode,
 				orgCodes,
-				tenantCodes
+				tenantCode
 			)
 
 			// 7. Remove mentor from DB
@@ -1375,7 +1356,7 @@ module.exports = class AdminService {
 			return []
 		}
 	}
-	static async updateSessionsWithAssignedMentor(mentorUserId, userOrgCode, userTenantCode, orgCodes, tenantCodes) {
+	static async updateSessionsWithAssignedMentor(mentorUserId, userOrgCode, userTenantCode, orgCodes, tenantCode) {
 		try {
 			// Use user's tenant code for database queries to get exact sessions
 			const sessionsToUpdate = await sessionQueries.getSessionsAssignedToMentor(mentorUserId, userTenantCode)
@@ -1384,7 +1365,7 @@ module.exports = class AdminService {
 			}
 
 			// Use combined codes for notifications (user + defaults)
-			await this.notifyAttendeesAboutSessionDeletion(sessionsToUpdate, orgCodes, tenantCodes)
+			await this.notifyAttendeesAboutSessionDeletion(sessionsToUpdate, orgCodes, tenantCode)
 
 			// Use user's tenant code for database updates
 			const sessionIds = [...new Set(sessionsToUpdate.map((s) => s.id))]
@@ -1409,14 +1390,14 @@ module.exports = class AdminService {
 		}
 	}
 
-	static async notifyMenteesAboutMentorDeletion(mentees, mentorName, orgCodes, tenantCodes) {
+	static async notifyMenteesAboutMentorDeletion(mentees, mentorName, orgCodes, tenantCode) {
 		return await NotificationHelper.sendGenericNotification({
 			recipients: mentees,
 			templateCode: process.env.MENTOR_DELETION_NOTIFICATION_EMAIL_TEMPLATE,
 			orgCode: orgCodes,
 			templateData: { mentorName },
 			subjectData: { mentorName },
-			tenantCodes,
+			tenantCode,
 		})
 	}
 
@@ -1438,7 +1419,7 @@ module.exports = class AdminService {
 		}
 	}
 
-	static async rejectSessionRequestsDueToMentorDeletion(sessionRequests, orgCodes, tenantCodes) {
+	static async rejectSessionRequestsDueToMentorDeletion(sessionRequests, orgCodes, tenantCode) {
 		try {
 			for (const request of sessionRequests) {
 				// Mark request as rejected
@@ -1446,7 +1427,7 @@ module.exports = class AdminService {
 					request.requestee_id,
 					request.id,
 					'Mentor no longer available',
-					tenantCodes[0]
+					tenantCode
 				)
 
 				// Get mentee details for notification
@@ -1455,7 +1436,7 @@ module.exports = class AdminService {
 					{
 						attributes: ['name', 'email'],
 					},
-					tenantCodes[0]
+					tenantCode
 				)
 
 				if (menteeDetails.length > 0) {
@@ -1466,7 +1447,7 @@ module.exports = class AdminService {
 						orgCode: orgCodes,
 						templateData: { sessionName: request.title },
 						subjectData: { sessionName: request.title },
-						tenantCodes,
+						tenantCode,
 					})
 				}
 			}
@@ -1479,7 +1460,7 @@ module.exports = class AdminService {
 		}
 	}
 
-	static async notifySessionManagersAboutMentorDeletion(sessions, mentorName, orgCodes, tenantCodes) {
+	static async notifySessionManagersAboutMentorDeletion(sessions, mentorName, orgCodes, tenantCode) {
 		try {
 			const templateCode = process.env.SESSION_MANAGER_MENTOR_DELETION_EMAIL_TEMPLATE
 			if (!templateCode) {
@@ -1505,7 +1486,7 @@ module.exports = class AdminService {
 					{
 						attributes: ['name', 'email'],
 					},
-					tenantCodes[0]
+					tenantCode
 				)
 
 				if (managerDetails.length > 0) {
@@ -1522,7 +1503,7 @@ module.exports = class AdminService {
 						orgCode: orgCodes,
 						templateData: { mentorName, sessionList },
 						subjectData: { mentorName },
-						tenantCodes,
+						tenantCode,
 					})
 				}
 			})
@@ -1536,7 +1517,7 @@ module.exports = class AdminService {
 		}
 	}
 
-	static async notifySessionManagersAboutMenteeDeletion(sessions, menteeName, orgCodes, tenantCodes) {
+	static async notifySessionManagersAboutMenteeDeletion(sessions, menteeName, orgCodes, tenantCode) {
 		try {
 			const templateCode = process.env.SESSION_MANAGER_MENTEE_DELETION_EMAIL_TEMPLATE
 			if (!templateCode) {
@@ -1562,7 +1543,7 @@ module.exports = class AdminService {
 					{
 						attributes: ['name', 'email'],
 					},
-					tenantCodes[0]
+					tenantCode
 				)
 
 				if (managerDetails.length > 0) {
@@ -1579,7 +1560,7 @@ module.exports = class AdminService {
 						orgCode: orgCodes,
 						templateData: { menteeName: menteeName, sessionList: sessionList },
 						subjectData: { menteeName: menteeName },
-						tenantCodes,
+						tenantCode,
 					})
 				}
 			})
@@ -1593,7 +1574,7 @@ module.exports = class AdminService {
 		}
 	}
 
-	static async notifyAttendeesAboutSessionDeletion(sessions, orgCodes, tenantCodes) {
+	static async notifyAttendeesAboutSessionDeletion(sessions, orgCodes, tenantCode) {
 		try {
 			const templateCode = process.env.SESSION_DELETED_MENTOR_DELETION_EMAIL_TEMPLATE
 			if (!templateCode) {
@@ -1603,7 +1584,6 @@ module.exports = class AdminService {
 
 			// Use first organization and tenant codes for database queries
 			const orgCode = Array.isArray(orgCodes) ? orgCodes[0] : orgCodes
-			const tenantCode = Array.isArray(tenantCodes) ? tenantCodes[0] : tenantCodes
 
 			// Group sessions by attendee
 			const sessionsByAttendee = {}
@@ -1633,7 +1613,7 @@ module.exports = class AdminService {
 							orgCode: orgCodes,
 							templateData: { sessionName: session.title },
 							subjectData: { sessionName: session.title },
-							tenantCodes,
+							tenantCode,
 						})
 					}
 				}
@@ -1885,7 +1865,7 @@ module.exports = class AdminService {
 			// Warm up Forms cache (get all forms dynamically)
 			try {
 				// Get all forms from database instead of hardcoding specific forms
-				const allForms = await formQueries.findFormsByFilter({}, [tenantCode])
+				const allForms = await formQueries.findFormsByFilter({}, tenantCode)
 
 				for (const form of allForms) {
 					if (form.type && form.sub_type) {

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -402,10 +402,9 @@ module.exports = class AdminService {
 						false,
 						true,
 						orgCodes,
-						userTenantCode,
 						organizationCode,
 						userTenantCode
-					) // (sessionsDetails, received, sent, orgCodes, tenantCode)
+					) // (sessionsDetails, received, sent, orgCodes, orgCode, tenantCode)
 				}
 
 				if (isMentor && receivedSessions.length > 0) {
@@ -414,10 +413,9 @@ module.exports = class AdminService {
 						true,
 						false,
 						orgCodes,
-						userTenantCode,
 						organizationCode,
 						userTenantCode
-					) // (sessionsDetails, received, sent, orgCodes, tenantCode)
+					) // (sessionsDetails, received, sent, orgCodes, orgCode, tenantCode)
 				}
 			}
 

--- a/src/services/availability.js
+++ b/src/services/availability.js
@@ -256,7 +256,7 @@ module.exports = class availabilityHelper {
 				user_id: userId,
 				tenant_code: tenantCode,
 			}
-			let userAvailabilities = await availabilityQueries.findAvailability(filter)
+			let userAvailabilities = await availabilityQueries.findAvailability(filter, tenantCode)
 
 			const sessionOptions = {
 				attributes: ['id', 'title', 'description', 'start_date', 'end_date', 'mentor_id', 'created_by'],
@@ -268,6 +268,7 @@ module.exports = class availabilityHelper {
 					},
 					mentor_id: userId,
 				},
+				tenantCode,
 				sessionOptions
 			)
 
@@ -349,13 +350,14 @@ module.exports = class availabilityHelper {
 				user_id: userId,
 				tenant_code: tenantCode,
 			}
-			let userAvailabilities = await availabilityQueries.findAvailability(filter)
+			let userAvailabilities = await availabilityQueries.findAvailability(filter, tenantCode)
 			const sessions = await sessionQueries.findAll(
 				{
 					start_date: {
 						[Op.between]: [query.startEpoch, query.endEpoch],
 					},
 				},
+				tenantCode,
 				{}
 			)
 			if (userAvailabilities.length === 0) {
@@ -423,13 +425,14 @@ module.exports = class availabilityHelper {
 				],
 				tenant_code: tenantCode,
 			}
-			let userAvailabilities = await availabilityQueries.findAvailability(filter)
+			let userAvailabilities = await availabilityQueries.findAvailability(filter, tenantCode)
 			const sessions = await sessionQueries.findAll(
 				{
 					start_date: {
 						[Op.between]: [query.startEpoch, query.endEpoch],
 					},
 				},
+				tenantCode,
 				{}
 			)
 			if (userAvailabilities.length === 0) {

--- a/src/services/connections.js
+++ b/src/services/connections.js
@@ -255,7 +255,7 @@ module.exports = class ConnectionHelper {
 				userExtensionsModelName,
 				'organization_code',
 				[],
-				[tenantCode]
+				tenantCode
 			)
 
 			const friendDetailsMap = friendDetails.reduce((acc, friend) => {
@@ -494,7 +494,7 @@ module.exports = class ConnectionHelper {
 					userExtensionsModelName,
 					'organization_code',
 					[],
-					[tenantCode]
+					tenantCode
 				)
 			}
 			const userIds = extensionDetails.data.map((item) => item.user_id)
@@ -573,7 +573,6 @@ module.exports = class ConnectionHelper {
 				})
 			}
 
-			const tenantCodes = [tenantCode]
 			const orgCodes = [orgCode, defaults.orgCode]
 
 			// Get email template
@@ -655,7 +654,6 @@ module.exports = class ConnectionHelper {
 				})
 			}
 
-			const tenantCodes = [tenantCode]
 			const orgCodes = [orgCode, defaults.orgCode]
 
 			// Get email template

--- a/src/services/connections.js
+++ b/src/services/connections.js
@@ -573,7 +573,7 @@ module.exports = class ConnectionHelper {
 				})
 			}
 
-			const tenantCodes = [tenantCode, defaults.tenantCode]
+			const tenantCodes = [tenantCode]
 			const orgCodes = [orgCode, defaults.orgCode]
 
 			// Get email template
@@ -655,7 +655,7 @@ module.exports = class ConnectionHelper {
 				})
 			}
 
-			const tenantCodes = [tenantCode, defaults.tenantCode]
+			const tenantCodes = [tenantCode]
 			const orgCodes = [orgCode, defaults.orgCode]
 
 			// Get email template

--- a/src/services/default-rule.js
+++ b/src/services/default-rule.js
@@ -135,9 +135,7 @@ module.exports = class DefaultRuleHelper {
 					statusCode: httpStatusCode.bad_request,
 					responseCode: 'CLIENT_ERROR',
 				})
-			const validation = await this.validateFields({ [Op.in]: [orgCode, defaults.orgCode] }, bodyData, {
-				[Op.in]: [tenantCode, defaults.tenantCode],
-			})
+			const validation = await this.validateFields({ [Op.in]: [orgCode, defaults.orgCode] }, bodyData, tenantCode)
 
 			if (!validation.isValid) {
 				return responses.failureResponse({
@@ -273,9 +271,7 @@ module.exports = class DefaultRuleHelper {
 					statusCode: httpStatusCode.bad_request,
 					responseCode: 'CLIENT_ERROR',
 				})
-			const validation = await this.validateFields({ [Op.in]: [orgCode, defaults.orgCode] }, bodyData, {
-				[Op.in]: [tenantCode, defaults.tenantCode],
-			})
+			const validation = await this.validateFields({ [Op.in]: [orgCode, defaults.orgCode] }, bodyData, tenantCode)
 
 			if (!validation.isValid) {
 				return responses.failureResponse({
@@ -345,7 +341,7 @@ module.exports = class DefaultRuleHelper {
 				})
 			const defaultRules = await defaultRuleQueries.findAndCountAll({
 				organization_code: { [Op.in]: [orgCode, defaults.orgCode] },
-				tenant_code: { [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenant_code: tenantCode,
 			})
 
 			return responses.successResponse({
@@ -387,7 +383,7 @@ module.exports = class DefaultRuleHelper {
 			const defaultRule = await defaultRuleQueries.findOne({
 				id: ruleId,
 				organization_code: { [Op.in]: [orgCode, defaults.orgCode] },
-				tenant_code: { [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenant_code: tenantCode,
 			})
 			if (!defaultRule) {
 				return responses.failureResponse({

--- a/src/services/default-rule.js
+++ b/src/services/default-rule.js
@@ -30,7 +30,7 @@ module.exports = class DefaultRuleHelper {
 	 * The object contains a boolean `isValid` indicating if the validation passed and an array `errors` with the validation errors if any.
 	 */
 
-	static async validateFields(orgCodes, bodyData, tenantCodes) {
+	static async validateFields(orgCodes, bodyData, tenantCode) {
 		const isSessionType =
 			bodyData.type === common.DEFAULT_RULES.SESSION_TYPE && !bodyData.is_target_from_sessions_mentor
 		const modelNamePromise = isSessionType ? sessionQueries.getModelName() : mentorExtensionQueries.getModelName()
@@ -40,14 +40,14 @@ module.exports = class DefaultRuleHelper {
 		const [modelName, mentorModelName] = await Promise.all([modelNamePromise, mentorModelNamePromise])
 
 		const validFieldsPromise = Promise.all([
-			entityTypeQueries.findAllEntityTypes(orgCodes, tenantCodes, ['id', 'data_type'], {
+			entityTypeQueries.findAllEntityTypes(orgCodes, tenantCode, ['id', 'data_type'], {
 				status: common.ACTIVE_STATUS,
 				value: bodyData.target_field,
 				model_names: { [Op.contains]: [modelName] },
 				required: true,
 				allow_filtering: true,
 			}),
-			entityTypeQueries.findAllEntityTypes(orgCodes, tenantCodes, ['id', 'data_type'], {
+			entityTypeQueries.findAllEntityTypes(orgCodes, tenantCode, ['id', 'data_type'], {
 				status: common.ACTIVE_STATUS,
 				value: bodyData.requester_field,
 				model_names: { [Op.contains]: [mentorModelName] },

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -461,11 +461,14 @@ module.exports = class EntityHelper {
 				}
 			)
 
-			const deleteCount = await entityTypeQueries.deleteEntityTypesAndEntities({
-				status: common.ACTIVE_STATUS,
-				value: { [Op.in]: value },
-				tenant_code: tenantCode,
-			})
+			const deleteCount = await entityTypeQueries.deleteEntityTypesAndEntities(
+				{
+					status: common.ACTIVE_STATUS,
+					value: { [Op.in]: value },
+					tenant_code: tenantCode,
+				},
+				tenantCode
+			)
 
 			if (deleteCount === 0) {
 				return responses.failureResponse({

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -373,7 +373,7 @@ module.exports = class EntityHelper {
 		modelName,
 		orgCodeKey,
 		entityType,
-		tenantCodes = []
+		tenantCode
 	) {
 		try {
 			const defaults = await getDefaults()
@@ -394,21 +394,16 @@ module.exports = class EntityHelper {
 				orgCodes.push(defaults.orgCode)
 			}
 
-			// Tenant isolation: only use the provided tenant codes, no default tenant fallback
-
 			const additionalFilters = {
 				has_entities: true,
 			}
 			if (entityType && entityType.length > 0) {
 				additionalFilters.value = entityType
 			}
-			// get entityTypes with entities data using cache
-			// Use first tenant/org as user context - cache helper handles defaults internally
-			const primaryTenantCode = tenantCodes[0]
 			const primaryOrgCode = orgCodes[0] || defaults.orgCode
 			let entityTypesWithEntities = await entityTypeCache.getEntityTypesAndEntitiesForModel(
 				Array.isArray(modelName) ? modelName[0] : modelName,
-				primaryTenantCode,
+				tenantCode,
 				primaryOrgCode,
 				additionalFilters
 			)

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -160,7 +160,7 @@ module.exports = class EntityHelper {
 				})
 			const entities = await entityTypeQueries.findAllEntityTypes(
 				{ [Op.or]: [orgCode, defaults.orgCode] },
-				{ [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenantCode,
 				attributes
 			)
 
@@ -228,11 +228,9 @@ module.exports = class EntityHelper {
 				organization_code: {
 					[Op.in]: [orgCode, defaults.orgCode],
 				},
-				tenant_code: { [Op.in]: [defaults.tenantCode, tenantCode] },
+				tenant_code: tenantCode,
 			}
-			const entityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(filter, {
-				[Op.in]: [defaults.tenantCode, tenantCode],
-			})
+			const entityTypes = await entityTypeQueries.findUserEntityTypesAndEntities(filter, tenantCode)
 
 			const prunedEntities = removeDefaultOrgEntityTypes(entityTypes, defaults.orgCode)
 
@@ -396,9 +394,7 @@ module.exports = class EntityHelper {
 				orgCodes.push(defaults.orgCode)
 			}
 
-			if (!tenantCodes.includes(defaults.tenantCode)) {
-				tenantCodes.push(defaults.tenantCode)
-			}
+			// Tenant isolation: only use the provided tenant codes, no default tenant fallback
 
 			const additionalFilters = {
 				has_entities: true,
@@ -408,7 +404,7 @@ module.exports = class EntityHelper {
 			}
 			// get entityTypes with entities data using cache
 			// Use first tenant/org as user context - cache helper handles defaults internally
-			const primaryTenantCode = tenantCodes[0] || defaults.tenantCode
+			const primaryTenantCode = tenantCodes[0]
 			const primaryOrgCode = orgCodes[0] || defaults.orgCode
 			let entityTypesWithEntities = await entityTypeCache.getEntityTypesAndEntitiesForModel(
 				Array.isArray(modelName) ? modelName[0] : modelName,
@@ -457,7 +453,7 @@ module.exports = class EntityHelper {
 			// Get entity types before deletion to clear cache
 			const entitiesToDelete = await entityTypeQueries.findAllEntityTypes(
 				{}, // No org code filter for this operation
-				{ [Op.in]: [tenantCode] },
+				tenantCode,
 				['value', 'model_names', 'organization_code'],
 				{
 					status: common.ACTIVE_STATUS,
@@ -632,7 +628,7 @@ module.exports = class EntityHelper {
 			const defaults = await getDefaults()
 			const allEntityTypes = await entityTypeQueries.findAllEntityTypes(
 				{ [Op.or]: [orgCode, defaults.orgCode] },
-				{ [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenantCode,
 				['model_names']
 			)
 

--- a/src/services/entity.js
+++ b/src/services/entity.js
@@ -247,7 +247,7 @@ module.exports = class EntityHelper {
 					],
 				}
 			}
-			const entities = await entityQueries.findAllEntities(filter, { [Op.in]: [tenantCode, defaults.tenantCode] })
+			const entities = await entityQueries.findAllEntities(filter, tenantCode)
 
 			if (!entities.length) {
 				return responses.failureResponse({
@@ -301,7 +301,7 @@ module.exports = class EntityHelper {
 					created_by: '0',
 				}
 			}
-			const entities = await entityQueries.findAllEntities(filter, { [Op.in]: [tenantCode, defaults.tenantCode] })
+			const entities = await entityQueries.findAllEntities(filter, tenantCode)
 
 			if (!entities.length) {
 				return responses.failureResponse({
@@ -435,7 +435,7 @@ module.exports = class EntityHelper {
 
 			let entityType = query.entity_type_id ? query.entity_type_id : ''
 			let filter = {
-				tenant_code: { [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenant_code: tenantCode,
 			}
 			if (entityType) {
 				filter['entity_type_id'] = entityType
@@ -455,7 +455,7 @@ module.exports = class EntityHelper {
 				// Optimized: Get entities with entity_type details included - eliminates N+1 queries for clients
 				entities = await entityQueries.getAllEntitiesWithEntityTypeDetails(
 					filter,
-					[defaults.tenantCode, tenantCode],
+					[tenantCode],
 					pageNo,
 					pageSize,
 					searchText

--- a/src/services/entity.js
+++ b/src/services/entity.js
@@ -455,7 +455,7 @@ module.exports = class EntityHelper {
 				// Optimized: Get entities with entity_type details included - eliminates N+1 queries for clients
 				entities = await entityQueries.getAllEntitiesWithEntityTypeDetails(
 					filter,
-					[tenantCode],
+					tenantCode,
 					pageNo,
 					pageSize,
 					searchText

--- a/src/services/feedback.js
+++ b/src/services/feedback.js
@@ -372,14 +372,14 @@ const getFeedbackQuestions = async function (formCode, tenantCode) {
 
 		let questionSet = await questionSetQueries.findOneQuestionSet({
 			code: formCode,
-			tenant_code: { [Op.in]: [tenantCode, defaults.tenantCode] },
+			tenant_code: tenantCode,
 		})
 
 		let result = {}
 		if (questionSet && questionSet.questions) {
 			let questions = await questionsQueries.find({
 				id: questionSet.questions,
-				tenant_code: { [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenant_code: tenantCode,
 			})
 			const questionIndexMap = new Map()
 			questionSet.questions.forEach((id, index) => {

--- a/src/services/feedback.js
+++ b/src/services/feedback.js
@@ -247,7 +247,8 @@ module.exports = class MenteesHelper {
 				if (updateData.is_feedback_skipped) {
 					const rowsAffected = await sessionQueries.updateOne(
 						{ id: sessionId, tenant_code: tenantCode },
-						updateData
+						updateData,
+						tenantCode
 					)
 					if (rowsAffected == 0) {
 						return responses.failureResponse({
@@ -307,7 +308,8 @@ module.exports = class MenteesHelper {
 							mentee_id: userId,
 							tenant_code: tenantCode,
 						},
-						updateData
+						updateData,
+						tenantCode
 					)
 					if (attendeeRowsAffected[0] == 0) {
 						return responses.failureResponse({

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -182,7 +182,6 @@ module.exports = class FormsHelper {
 				filter.organization_code = { [Op.in]: [orgCode, defaults.orgCode] }
 			}
 
-			// Tenant isolation: only use the current tenant
 			const forms = await formQueries.findFormsByFilter(filter, tenantCode)
 
 			if (!forms || forms.length === 0) {

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -173,8 +173,8 @@ module.exports = class FormsHelper {
 				filter.organization_code = { [Op.in]: [orgCode, defaults.orgCode] }
 			}
 
-			// Business logic: Try both current tenant and default tenant
-			const tenantCodes = [tenantCode, defaults.tenantCode]
+			// Tenant isolation: only use the current tenant
+			const tenantCodes = [tenantCode]
 			const forms = await formQueries.findFormsByFilter(filter, tenantCodes)
 
 			if (!forms || forms.length === 0) {
@@ -219,8 +219,7 @@ module.exports = class FormsHelper {
 				})
 
 			// Fetch all forms from database (no "all forms" cache to avoid duplication)
-			const formsVersionData =
-				(await form.getAllFormsVersion({ [Op.in]: [defaults.tenantCode, tenantCode] })) || {}
+			const formsVersionData = (await form.getAllFormsVersion(tenantCode)) || {}
 
 			// Cache each individual form for future individual reads
 			try {

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -29,16 +29,7 @@ module.exports = class FormsHelper {
 			bodyData['organization_code'] = orgCode
 			const form = await formQueries.createForm(bodyData, tenantCode, orgCode)
 
-			//			await KafkaProducer.clearInternalCache('formVersion')
-
-			// Invalidate cache so stale fallback (default org) is not served
-			try {
-				if (bodyData.type && bodyData.sub_type) {
-					await cacheHelper.forms.delete(tenantCode, orgCode, bodyData.type, bodyData.sub_type)
-				}
-			} catch (cacheError) {
-				console.error('Failed to invalidate form cache:', cacheError)
-			}
+			await KafkaProducer.clearInternalCache('formVersion')
 
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
@@ -192,8 +183,8 @@ module.exports = class FormsHelper {
 				})
 			}
 
-			// Business logic: Prefer current org over default org
-			const form = forms.find((f) => f.organization_code === orgCode) || forms[0]
+			// Business logic: Prefer current tenant over default tenant
+			const form = forms.find((f) => f.tenant_code === tenantCode) || forms[0]
 
 			// Cache the result if it was searched by type and subtype
 			if (!id && bodyData?.type && bodyData?.sub_type) {
@@ -247,10 +238,7 @@ module.exports = class FormsHelper {
 									)
 
 									if (completeFormData && completeFormData.length > 0) {
-										// Prefer custom org form over default org form
-										const formData =
-											completeFormData.find((f) => f.organization_code !== defaults.orgCode) ||
-											completeFormData[0]
+										const formData = completeFormData[0]
 										if (formData.sub_type) {
 											await cacheHelper.forms.set(
 												tenantCode,

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -31,6 +31,15 @@ module.exports = class FormsHelper {
 
 			//			await KafkaProducer.clearInternalCache('formVersion')
 
+			// Invalidate cache so stale fallback (default org) is not served
+			try {
+				if (bodyData.type && bodyData.sub_type) {
+					await cacheHelper.forms.delete(tenantCode, orgCode, bodyData.type, bodyData.sub_type)
+				}
+			} catch (cacheError) {
+				console.error('Failed to invalidate form cache:', cacheError)
+			}
+
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
 				message: 'FORM_CREATED_SUCCESSFULLY',
@@ -74,7 +83,7 @@ module.exports = class FormsHelper {
 
 				if (!originalForm) {
 					// Cache miss: fallback to database query
-					const originalForms = await formQueries.findFormsByFilter(filter, [tenantCode])
+					const originalForms = await formQueries.findFormsByFilter(filter, tenantCode)
 					originalForm = originalForms && originalForms.length > 0 ? originalForms[0] : null
 				}
 			}
@@ -174,8 +183,7 @@ module.exports = class FormsHelper {
 			}
 
 			// Tenant isolation: only use the current tenant
-			const tenantCodes = [tenantCode]
-			const forms = await formQueries.findFormsByFilter(filter, tenantCodes)
+			const forms = await formQueries.findFormsByFilter(filter, tenantCode)
 
 			if (!forms || forms.length === 0) {
 				return responses.failureResponse({
@@ -185,8 +193,8 @@ module.exports = class FormsHelper {
 				})
 			}
 
-			// Business logic: Prefer current tenant over default tenant
-			const form = forms.find((f) => f.tenant_code === tenantCode) || forms[0]
+			// Business logic: Prefer current org over default org
+			const form = forms.find((f) => f.organization_code === orgCode) || forms[0]
 
 			// Cache the result if it was searched by type and subtype
 			if (!id && bodyData?.type && bodyData?.sub_type) {
@@ -236,11 +244,14 @@ module.exports = class FormsHelper {
 									// Fetch complete form data by type (this should include sub_type)
 									const completeFormData = await formQueries.findFormsByFilter(
 										{ type: formVersion.type },
-										[tenantCode]
+										tenantCode
 									)
 
 									if (completeFormData && completeFormData.length > 0) {
-										const formData = completeFormData[0]
+										// Prefer custom org form over default org form
+										const formData =
+											completeFormData.find((f) => f.organization_code !== defaults.orgCode) ||
+											completeFormData[0]
 										if (formData.sub_type) {
 											await cacheHelper.forms.set(
 												tenantCode,

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -29,7 +29,7 @@ module.exports = class FormsHelper {
 			bodyData['organization_code'] = orgCode
 			const form = await formQueries.createForm(bodyData, tenantCode, orgCode)
 
-			await KafkaProducer.clearInternalCache('formVersion')
+			//await KafkaProducer.clearInternalCache('formVersion')
 
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,

--- a/src/services/mentees.js
+++ b/src/services/mentees.js
@@ -698,7 +698,7 @@ module.exports = class MenteesHelper {
 			requesterId: userId,
 			roles: roles,
 			requesterOrganizationCode: organizationCode,
-			tenantCode: { [Op.in]: [tenantCode, defaults.tenantCode] },
+			tenantCode: tenantCode,
 		})
 
 		if (defaultRuleFilter.error && defaultRuleFilter.error.missingField) {
@@ -1458,7 +1458,7 @@ module.exports = class MenteesHelper {
 					modelName,
 					{},
 					tenantCodes,
-					defaults.tenantCode ? defaults.tenantCode : ''
+					''
 				)
 				if (getEntityTypesWithEntities.success && getEntityTypesWithEntities.result) {
 					let entityTypesWithEntities = getEntityTypesWithEntities.result

--- a/src/services/mentees.js
+++ b/src/services/mentees.js
@@ -723,7 +723,7 @@ module.exports = class MenteesHelper {
 				common.sessionModelName,
 				'mentor_organization_id',
 				[],
-				[tenantCode]
+				tenantCode
 			)
 		}
 
@@ -876,7 +876,7 @@ module.exports = class MenteesHelper {
 					common.sessionModelName,
 					'mentor_organization_id',
 					[],
-					[tenantCode]
+					tenantCode
 				)
 				sessionDetails.rows = await this.sessionMentorDetails(sessionDetails.rows, tenantCode)
 				sessionDetails.rows = sessionDetails.rows.map((r) => ({ ...r, is_enrolled: true }))
@@ -1415,7 +1415,6 @@ module.exports = class MenteesHelper {
 			const filter_type = filterType !== '' ? filterType : common.MENTOR_ROLE
 
 			let organization_codes = []
-			let tenantCodes = []
 			let organizationInfo = []
 			const organizations = await getOrgIdAndEntityTypes.getOrganizationIdBasedOnPolicy(
 				tokenInformation.id,
@@ -1428,7 +1427,6 @@ module.exports = class MenteesHelper {
 
 			if (organizations && organizations.result.organizationInfo?.length > 0) {
 				organization_codes = organizations.result.organizationCodes
-				tenantCodes = organizations.result.tenantCodes
 
 				organizationInfo = organizations.result.organizationInfo
 				if (organizationInfo.length > 1) {
@@ -1455,8 +1453,7 @@ module.exports = class MenteesHelper {
 					defaults.orgCode ? defaults.orgCode : '',
 					modelName,
 					{},
-					tenantCodes,
-					''
+					tenantCode
 				)
 				if (getEntityTypesWithEntities.success && getEntityTypesWithEntities.result) {
 					let entityTypesWithEntities = getEntityTypesWithEntities.result
@@ -1683,7 +1680,7 @@ module.exports = class MenteesHelper {
 						userExtensionModelName,
 						'organization_code',
 						[],
-						[tenantCode]
+						tenantCode
 					)
 					if (Array.isArray(processedData)) {
 						extensionDetails.data = processedData

--- a/src/services/mentors.js
+++ b/src/services/mentors.js
@@ -107,7 +107,7 @@ module.exports = class MentorsHelper {
 				requesterId: menteeUserId,
 				roles: roles,
 				requesterOrganizationCode: orgCode,
-				tenantCode: { [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenantCode: tenantCode,
 			})
 
 			if (defaultRuleFilter.error && defaultRuleFilter.error.missingField) {
@@ -1375,7 +1375,7 @@ module.exports = class MentorsHelper {
 				requesterId: queryParams.menteeId ? queryParams.menteeId : userId,
 				roles: roles,
 				requesterOrganizationCode: orgCode,
-				tenantCode: { [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenantCode: tenantCode,
 			})
 
 			if (defaultRuleFilter.error && defaultRuleFilter.error.missingField) {

--- a/src/services/mentors.js
+++ b/src/services/mentors.js
@@ -162,7 +162,7 @@ module.exports = class MentorsHelper {
 				common.sessionModelName,
 				'mentor_organization_id',
 				[],
-				[tenantCode]
+				tenantCode
 			)
 
 			upcomingSessions.data = await this.sessionMentorDetails(upcomingSessions.data, tenantCode)
@@ -1518,7 +1518,7 @@ module.exports = class MentorsHelper {
 					userExtensionsModelName, // Use UserExtension model name for entity processing
 					'organization_code',
 					[], // Empty array means process ALL entity types for this model
-					[tenantCode]
+					tenantCode
 				)
 			}
 
@@ -1754,7 +1754,7 @@ module.exports = class MentorsHelper {
 				common.sessionModelName,
 				'mentor_organization_id',
 				[],
-				[tenantCode]
+				tenantCode
 			)
 
 			return responses.successResponse({

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -20,7 +20,6 @@ module.exports = class NotificationTemplateHelper {
 			const template = await notificationTemplateQueries.findOne(
 				{
 					code: bodyData.code,
-					tenant_code: tenantCode,
 					organization_code: tokenInformation.organization_code,
 				},
 				tenantCode
@@ -39,6 +38,17 @@ module.exports = class NotificationTemplateHelper {
 			bodyData['created_by'] = tokenInformation.id
 
 			const createdNotification = await notificationTemplateQueries.create(bodyData, tenantCode)
+
+			// Invalidate cache so stale fallback (default org) is not served
+			try {
+				await cacheHelper.notificationTemplates.delete(
+					tenantCode,
+					tokenInformation.organization_code,
+					bodyData.code
+				)
+			} catch (cacheError) {
+				console.error('❌ Failed to invalidate notification template cache:', cacheError)
+			}
 
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
@@ -76,6 +86,10 @@ module.exports = class NotificationTemplateHelper {
 			bodyData['organization_code'] = tokenInformation.organization_code
 			bodyData['updated_by'] = tokenInformation.id
 
+			// Fetch existing template BEFORE update to capture the old code for cache invalidation
+			const existingTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
+			const existingTemplate = existingTemplates?.[0]
+
 			const result = await notificationTemplateQueries.updateTemplate(filter, bodyData, tenantCode)
 			if (result == 0) {
 				return responses.failureResponse({
@@ -85,23 +99,22 @@ module.exports = class NotificationTemplateHelper {
 				})
 			}
 
-			// Delete old cache
-			const existingTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
-			const existingTemplate = existingTemplates?.[0]
-			const templateCode = bodyData.code || existingTemplate?.code || filter.code
+			// Delete cache for both old code and new code (in case code was changed)
+			const oldCode = existingTemplate?.code
+			const newCode = bodyData.code
 			try {
-				if (templateCode) {
+				if (oldCode) {
 					await cacheHelper.notificationTemplates.delete(
 						tenantCode,
 						tokenInformation.organization_code,
-						templateCode
+						oldCode
 					)
 				}
-				if (existingTemplate?.code && existingTemplate.code !== templateCode) {
+				if (newCode && newCode !== oldCode) {
 					await cacheHelper.notificationTemplates.delete(
 						tenantCode,
 						tokenInformation.organization_code,
-						existingTemplate.code
+						newCode
 					)
 				}
 			} catch (cacheError) {
@@ -231,21 +244,18 @@ module.exports = class NotificationTemplateHelper {
 			// Cache each individual template for future single reads
 			if (notificationTemplates && notificationTemplates.length > 0) {
 				try {
-					console.log(`Caching ${notificationTemplates.length} notification templates individually...`)
-					const cachePromises = []
-
+					const templatesByCode = {}
 					for (const template of notificationTemplates) {
-						if (template.code) {
-							const cachePromise = cacheHelper.notificationTemplates.set(
-								tenantCode,
-								organizationCode,
-								template.code,
-								template
-							)
-							cachePromises.push(cachePromise)
+						if (!template.code) continue
+						// Only set if not yet seen, or if this template belongs to user's own org (higher priority)
+						if (!templatesByCode[template.code] || template.organization_code === organizationCode) {
+							templatesByCode[template.code] = template
 						}
 					}
 
+					const cachePromises = Object.entries(templatesByCode).map(([code, template]) =>
+						cacheHelper.notificationTemplates.set(tenantCode, organizationCode, code, template)
+					)
 					await Promise.all(cachePromises)
 				} catch (cacheError) {
 					console.warn('Failed to cache individual notification templates:', cacheError)
@@ -309,12 +319,8 @@ module.exports = class NotificationTemplateHelper {
 				return null
 			}
 
-			// Business logic: Prefer current tenant and org over default
-			let selectedTemplate =
-				templateData.find((t) => t.organization_code === orgCode && t.tenant_code === tenantCode) ||
-				templateData.find((t) => t.organization_code === orgCode) ||
-				templateData.find((t) => t.tenant_code === tenantCode) ||
-				templateData[0]
+			// Business logic: Prefer user's org template over default org template
+			let selectedTemplate = templateData.find((t) => t.organization_code === orgCode) || templateData[0]
 
 			// Business logic: Compose template with header and footer
 			if (selectedTemplate && selectedTemplate.email_header) {

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -152,10 +152,9 @@ module.exports = class NotificationTemplateHelper {
 				})
 			}
 
-			// Business logic: Build filter for both current and default org/tenant
 			let filter = {
 				organization_code: organizationCode ? [organizationCode, defaults.orgCode] : [defaults.orgCode],
-				tenant_code: [tenantCode, defaults.tenantCode],
+				tenant_code: tenantCode,
 			}
 
 			if (id) {
@@ -219,10 +218,9 @@ module.exports = class NotificationTemplateHelper {
 				})
 			}
 
-			// Business logic: Build filter for both current and default org/tenant
 			const filter = {
 				organization_code: organizationCode ? [organizationCode, defaults.orgCode] : [defaults.orgCode],
-				tenant_code: [tenantCode, defaults.tenantCode],
+				tenant_code: tenantCode,
 			}
 
 			const notificationTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
@@ -294,13 +292,12 @@ module.exports = class NotificationTemplateHelper {
 				})
 			}
 
-			// Business logic: Build filter for both current and default org/tenant
 			const filter = {
 				code: code,
 				type: 'email',
 				status: 'active',
 				organization_code: orgCode ? [orgCode, defaults.orgCode] : [defaults.orgCode],
-				tenant_code: [tenantCode, defaults.tenantCode],
+				tenant_code: tenantCode,
 			}
 
 			const templateData = await notificationTemplateQueries.findTemplatesByFilter(filter)
@@ -369,13 +366,12 @@ module.exports = class NotificationTemplateHelper {
 				})
 			}
 
-			// Business logic: Build filter for header template
 			const filter = {
 				code: header,
 				type: 'emailHeader',
 				status: 'active',
 				organization_code: orgCode ? [orgCode, defaults.orgCode] : [defaults.orgCode],
-				tenant_code: [tenantCode, defaults.tenantCode],
+				tenant_code: tenantCode,
 			}
 
 			const headerData = await notificationTemplateQueries.findTemplatesByFilter(filter)
@@ -423,13 +419,12 @@ module.exports = class NotificationTemplateHelper {
 				})
 			}
 
-			// Business logic: Build filter for footer template
 			const filter = {
 				code: footer,
 				type: 'emailFooter',
 				status: 'active',
 				organization_code: orgCode ? [orgCode, defaults.orgCode] : [defaults.orgCode],
-				tenant_code: [tenantCode, defaults.tenantCode],
+				tenant_code: tenantCode,
 			}
 
 			const footerData = await notificationTemplateQueries.findTemplatesByFilter(filter)

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -17,11 +17,14 @@ module.exports = class NotificationTemplateHelper {
 
 	static async create(bodyData, tokenInformation, tenantCode) {
 		try {
-			const template = await notificationTemplateQueries.findOne({
-				code: bodyData.code,
-				tenant_code: tenantCode,
-				organization_code: tokenInformation.organization_code,
-			})
+			const template = await notificationTemplateQueries.findOne(
+				{
+					code: bodyData.code,
+					tenant_code: tenantCode,
+					organization_code: tokenInformation.organization_code,
+				},
+				tenantCode
+			)
 			if (template) {
 				return responses.failureResponse({
 					message: 'NOTIFICATION_TEMPLATE_ALREADY_EXISTS',

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -39,17 +39,6 @@ module.exports = class NotificationTemplateHelper {
 
 			const createdNotification = await notificationTemplateQueries.create(bodyData, tenantCode)
 
-			// Invalidate cache so stale fallback (default org) is not served
-			try {
-				await cacheHelper.notificationTemplates.delete(
-					tenantCode,
-					tokenInformation.organization_code,
-					bodyData.code
-				)
-			} catch (cacheError) {
-				console.error('❌ Failed to invalidate notification template cache:', cacheError)
-			}
-
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
 				message: 'NOTIFICATION_TEMPLATE_CREATED_SUCCESSFULLY',
@@ -86,10 +75,6 @@ module.exports = class NotificationTemplateHelper {
 			bodyData['organization_code'] = tokenInformation.organization_code
 			bodyData['updated_by'] = tokenInformation.id
 
-			// Fetch existing template BEFORE update to capture the old code for cache invalidation
-			const existingTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
-			const existingTemplate = existingTemplates?.[0]
-
 			const result = await notificationTemplateQueries.updateTemplate(filter, bodyData, tenantCode)
 			if (result == 0) {
 				return responses.failureResponse({
@@ -99,22 +84,23 @@ module.exports = class NotificationTemplateHelper {
 				})
 			}
 
-			// Delete cache for both old code and new code (in case code was changed)
-			const oldCode = existingTemplate?.code
-			const newCode = bodyData.code
+			// Delete old cache
+			const existingTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
+			const existingTemplate = existingTemplates?.[0]
+			const templateCode = bodyData.code || existingTemplate?.code || filter.code
 			try {
-				if (oldCode) {
+				if (templateCode) {
 					await cacheHelper.notificationTemplates.delete(
 						tenantCode,
 						tokenInformation.organization_code,
-						oldCode
+						templateCode
 					)
 				}
-				if (newCode && newCode !== oldCode) {
+				if (existingTemplate?.code && existingTemplate.code !== templateCode) {
 					await cacheHelper.notificationTemplates.delete(
 						tenantCode,
 						tokenInformation.organization_code,
-						newCode
+						existingTemplate.code
 					)
 				}
 			} catch (cacheError) {
@@ -244,18 +230,21 @@ module.exports = class NotificationTemplateHelper {
 			// Cache each individual template for future single reads
 			if (notificationTemplates && notificationTemplates.length > 0) {
 				try {
-					const templatesByCode = {}
+					console.log(`Caching ${notificationTemplates.length} notification templates individually...`)
+					const cachePromises = []
+
 					for (const template of notificationTemplates) {
-						if (!template.code) continue
-						// Only set if not yet seen, or if this template belongs to user's own org (higher priority)
-						if (!templatesByCode[template.code] || template.organization_code === organizationCode) {
-							templatesByCode[template.code] = template
+						if (template.code) {
+							const cachePromise = cacheHelper.notificationTemplates.set(
+								tenantCode,
+								organizationCode,
+								template.code,
+								template
+							)
+							cachePromises.push(cachePromise)
 						}
 					}
 
-					const cachePromises = Object.entries(templatesByCode).map(([code, template]) =>
-						cacheHelper.notificationTemplates.set(tenantCode, organizationCode, code, template)
-					)
 					await Promise.all(cachePromises)
 				} catch (cacheError) {
 					console.warn('Failed to cache individual notification templates:', cacheError)

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -387,37 +387,13 @@ module.exports = class OrgAdminService {
 	 * @name 							- inheritEntityType
 	 * @param {String} entityValue 		- Entity type value
 	 * @param {String} entityLabel 		- Entity type label
-	 * @param {Integer} userOrgId 		- User org id
+	 * @param {String} userOrgCode 		- User org code
 	 * @param {Object} decodedToken 	- User token details
 	 * @returns {Promise<Object>} 		- A Promise that resolves to a response object.
 	 */
 
-	static async inheritEntityType(entityValue, entityLabel, userOrgId, decodedToken, tenantCode) {
+	static async inheritEntityType(entityValue, entityLabel, userOrgCode, decodedToken, tenantCode) {
 		try {
-			// Get default organisation details
-			let defaultOrgDetails = await userRequests.fetchOrgDetails({
-				organizationCode: process.env.DEFAULT_ORGANISATION_CODE,
-			})
-
-			let defaultOrgId
-			if (defaultOrgDetails.success && defaultOrgDetails.data && defaultOrgDetails.data.result) {
-				defaultOrgId = String(defaultOrgDetails.data.result.id)
-			} else {
-				return responses.failureResponse({
-					message: 'DEFAULT_ORG_ID_NOT_SET',
-					statusCode: httpStatusCode.bad_request,
-					responseCode: 'CLIENT_ERROR',
-				})
-			}
-
-			if (String(defaultOrgId) === String(userOrgId)) {
-				return responses.failureResponse({
-					message: 'USER_IS_FROM_DEFAULT_ORG',
-					statusCode: httpStatusCode.bad_request,
-					responseCode: 'CLIENT_ERROR',
-				})
-			}
-
 			const defaults = await getDefaults()
 			if (!defaults.orgCode)
 				return responses.failureResponse({
@@ -431,6 +407,14 @@ module.exports = class OrgAdminService {
 					statusCode: httpStatusCode.bad_request,
 					responseCode: 'CLIENT_ERROR',
 				})
+
+			if (defaults.orgCode === userOrgCode) {
+				return responses.failureResponse({
+					message: 'USER_IS_FROM_DEFAULT_ORG',
+					statusCode: httpStatusCode.bad_request,
+					responseCode: 'CLIENT_ERROR',
+				})
+			}
 
 			// Fetch entity type data using organization_code and entityValue
 			const filter = {

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -434,6 +434,13 @@ module.exports = class OrgAdminService {
 					responseCode: 'CLIENT_ERROR',
 				})
 
+			// Fetch entity type data using organization_code and entityValue
+			const filter = {
+				value: entityValue,
+				organization_code: defaults.orgCode,
+				allow_filtering: true,
+			}
+
 			let entityTypeDetails = await entityTypeQueries.findOneEntityType(filter, tenantCode)
 
 			// If no matching data found return failure response

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -149,7 +149,7 @@ module.exports = class OrgAdminService {
 				removedSessionsDetail,
 				mentorDetails.organization_id ? mentorDetails.organization_id : '',
 				{ [Op.in]: [bodyData.organization_code, defaults.orgCode] },
-				{ [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenantCode,
 				tenantCode,
 				mentorDetails.organization_code
 			)
@@ -438,9 +438,7 @@ module.exports = class OrgAdminService {
 					responseCode: 'CLIENT_ERROR',
 				})
 
-			let entityTypeDetails = await entityTypeQueries.findOneEntityType(filter, {
-				[Op.in]: [defaults.tenantCode, tenantCode],
-			})
+			let entityTypeDetails = await entityTypeQueries.findOneEntityType(filter, tenantCode)
 
 			// If no matching data found return failure response
 			if (!entityTypeDetails) {
@@ -606,7 +604,7 @@ module.exports = class OrgAdminService {
 					await adminService.unenrollAndNotifySessionAttendees(
 						removedSessionsDetail,
 						{ [Op.in]: [orgCode, defaults.orgCode] },
-						{ [Op.in]: [tenantCode, defaults.tenantCode] },
+						tenantCode,
 						tenantCode,
 						orgCode
 					)
@@ -729,7 +727,7 @@ module.exports = class OrgAdminService {
 			const questionSets = await questionSetQueries.findQuestionSets(
 				{
 					code: { [Op.in]: [bodyData.mentee_feedback_question_set, bodyData.mentor_feedback_question_set] },
-					tenant_code: defaults.tenantCode,
+					tenant_code: tenantCode,
 				},
 				['id', 'code']
 			)
@@ -898,7 +896,7 @@ module.exports = class OrgAdminService {
 		// If not in cache, fetch from database
 		organizationDetails = await organisationExtensionQueries.getById(
 			{ [Op.in]: [defaults.orgCode, orgCode] },
-			{ [Op.in]: [defaults.tenantCode, tenantCode] }
+			tenantCode
 		)
 
 		if (!organizationDetails) {

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -403,7 +403,7 @@ module.exports = class OrgAdminService {
 
 			let defaultOrgId
 			if (defaultOrgDetails.success && defaultOrgDetails.data && defaultOrgDetails.data.result) {
-				defaultOrgId = defaultOrgDetails.data.result.id
+				defaultOrgId = String(defaultOrgDetails.data.result.id)
 			} else {
 				return responses.failureResponse({
 					message: 'DEFAULT_ORG_ID_NOT_SET',
@@ -412,19 +412,12 @@ module.exports = class OrgAdminService {
 				})
 			}
 
-			if (defaultOrgId === userOrgId) {
+			if (String(defaultOrgId) === String(userOrgId)) {
 				return responses.failureResponse({
 					message: 'USER_IS_FROM_DEFAULT_ORG',
 					statusCode: httpStatusCode.bad_request,
 					responseCode: 'CLIENT_ERROR',
 				})
-			}
-
-			// Fetch entity type data using defaultOrgId and entityValue
-			const filter = {
-				value: entityValue,
-				organization_id: defaultOrgId,
-				allow_filtering: true,
 			}
 
 			const defaults = await getDefaults()
@@ -441,6 +434,13 @@ module.exports = class OrgAdminService {
 					responseCode: 'CLIENT_ERROR',
 				})
 
+			// Fetch entity type data using organization_code and entityValue
+			const filter = {
+				value: entityValue,
+				organization_code: defaults.orgCode,
+				allow_filtering: true,
+			}
+
 			let entityTypeDetails = await entityTypeQueries.findOneEntityType(filter, tenantCode)
 
 			// If no matching data found return failure response
@@ -456,6 +456,7 @@ module.exports = class OrgAdminService {
 			entityTypeDetails.parent_id = entityTypeDetails.id
 			entityTypeDetails.label = entityLabel
 			entityTypeDetails.organization_id = userOrgId
+			entityTypeDetails.organization_code = decodedToken.organization_code
 			entityTypeDetails.created_by = decodedToken.id
 			entityTypeDetails.updated_by = decodedToken.id
 			delete entityTypeDetails.id
@@ -514,8 +515,8 @@ module.exports = class OrgAdminService {
 			// Get organization policies
 			const orgPolicies = await organisationExtensionQueries.findOrInsertOrganizationExtension(
 				orgId,
-				organizationDetails.data.result.name,
 				bodyData.organization_code,
+				organizationDetails.data.result.name,
 				tenantCode
 			)
 			if (!orgPolicies?.organization_id) {

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -437,7 +437,7 @@ module.exports = class OrgAdminService {
 			// Build data for inheriting entityType
 			entityTypeDetails.parent_id = entityTypeDetails.id
 			entityTypeDetails.label = entityLabel
-			entityTypeDetails.organization_id = userOrgId
+			entityTypeDetails.organization_id = decodedToken.organization_id
 			entityTypeDetails.organization_code = decodedToken.organization_code
 			entityTypeDetails.created_by = decodedToken.id
 			entityTypeDetails.updated_by = decodedToken.id

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -150,9 +150,7 @@ module.exports = class OrgAdminService {
 
 			const isAttendeesNotified = await adminService.unenrollAndNotifySessionAttendees(
 				removedSessionsDetail,
-				mentorDetails.organization_id ? mentorDetails.organization_id : '',
 				{ [Op.in]: [bodyData.organization_code, defaults.orgCode] },
-				tenantCode,
 				tenantCode,
 				mentorDetails.organization_code
 			)
@@ -608,7 +606,6 @@ module.exports = class OrgAdminService {
 					await adminService.unenrollAndNotifySessionAttendees(
 						removedSessionsDetail,
 						{ [Op.in]: [orgCode, defaults.orgCode] },
-						tenantCode,
 						tenantCode,
 						orgCode
 					)

--- a/src/services/question-set.js
+++ b/src/services/question-set.js
@@ -131,7 +131,7 @@ module.exports = class questionsSetHelper {
 
 			const filter = {
 				id: questionsSetId,
-				tenant_code: { [Op.in]: [tenantCode, defaults.tenantCode] },
+				tenant_code: tenantCode,
 			}
 			if (questionSetCode) {
 				filter.code = questionSetCode

--- a/src/services/questions.js
+++ b/src/services/questions.js
@@ -92,7 +92,7 @@ module.exports = class questionsHelper {
 					responseCode: 'CLIENT_ERROR',
 				})
 
-			const filter = { id: questionId, tenant_code: { [Op.in]: [tenantCode, defaults.tenantCode] } }
+			const filter = { id: questionId, tenant_code: tenantCode }
 			const question = await questionQueries.findOneQuestion(filter)
 			if (!question) {
 				return responses.failureResponse({

--- a/src/services/report-mapping.js
+++ b/src/services/report-mapping.js
@@ -33,11 +33,9 @@ module.exports = class ReportsHelper {
 
 	static async getMapping(code, organizationCode, tenantCode) {
 		try {
-			const readMapping = await mappingQueries.findReportRoleMappingByReportCode(
-				code,
-				[tenantCode],
-				[organizationCode]
-			)
+			const readMapping = await mappingQueries.findReportRoleMappingByReportCode(code, tenantCode, [
+				organizationCode,
+			])
 			if (!readMapping) {
 				return responses.failureResponse({
 					message: 'REPORT_MAPPING_NOT_FOUND',

--- a/src/services/report-type.js
+++ b/src/services/report-type.js
@@ -42,8 +42,7 @@ module.exports = class ReportsHelper {
 				})
 			}
 
-			// Try both current tenant and default tenant using array
-			const tenantCodes = [tenantCode, defaults.tenantCode]
+			const tenantCodes = [tenantCode]
 			const reportTypes = await reportTypeQueries.findReportTypesByTitle(title, tenantCodes)
 
 			if (!reportTypes || reportTypes.length === 0) {
@@ -54,8 +53,7 @@ module.exports = class ReportsHelper {
 				})
 			}
 
-			// Business logic: Prefer current tenant over default tenant
-			const reportType = reportTypes.find((rt) => rt.tenant_code === tenantCode) || reportTypes[0]
+			const reportType = reportTypes[0]
 
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,

--- a/src/services/report-type.js
+++ b/src/services/report-type.js
@@ -42,8 +42,7 @@ module.exports = class ReportsHelper {
 				})
 			}
 
-			const tenantCodes = [tenantCode]
-			const reportTypes = await reportTypeQueries.findReportTypesByTitle(title, tenantCodes)
+			const reportTypes = await reportTypeQueries.findReportTypesByTitle(title, tenantCode)
 
 			if (!reportTypes || reportTypes.length === 0) {
 				return responses.failureResponse({

--- a/src/services/report-type.js
+++ b/src/services/report-type.js
@@ -52,12 +52,10 @@ module.exports = class ReportsHelper {
 				})
 			}
 
-			const reportType = reportTypes[0]
-
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
 				message: 'REPORT_TYPE_FETCHED_SUCCESSFULLY',
-				result: reportType,
+				result: reportTypes[0],
 			})
 		} catch (error) {
 			throw error

--- a/src/services/reports.js
+++ b/src/services/reports.js
@@ -59,7 +59,7 @@ module.exports = class ReportsHelper {
 				tokenInformation.id,
 				tokenInformation.organization_code,
 				filter_type,
-				{ [Op.in]: [tenantCode, defaults.tenantCode] }
+				tenantCode
 			)
 
 			if (organizations.success && organizations.result) {
@@ -86,7 +86,7 @@ module.exports = class ReportsHelper {
 						modelName,
 						report_filter,
 						tenantCodes,
-						defaults.tenantCode ? defaults.tenantCode : ''
+						''
 					)
 
 					if (getEntityTypesWithEntities.success && getEntityTypesWithEntities.result) {
@@ -196,7 +196,7 @@ module.exports = class ReportsHelper {
 			// Validate report permissions
 			const reportPermission = await reportMappingQueries.findReportRoleMappingByReportCode(
 				reportCode,
-				[tenantCode, defaults.tenantCode],
+				[tenantCode],
 				[defaults.orgCode, orgCode]
 			)
 			if (!reportPermission || reportPermission.dataValues.role_title !== reportRole) {
@@ -215,7 +215,7 @@ module.exports = class ReportsHelper {
 					code: reportCode,
 					organization_code: { [Op.in]: [orgCode, defaults.orgCode] },
 				},
-				{ [Op.in]: [tenantCode, defaults.tenantCode] }
+				tenantCode
 			)
 			if (reportConfigWithOrgId.length > 0) {
 				reportConfig = reportConfigWithOrgId
@@ -226,7 +226,7 @@ module.exports = class ReportsHelper {
 						code: reportCode,
 						organization_code: { [Op.in]: [orgCode, defaults.orgCode] },
 					},
-					{ [Op.in]: [tenantCode, defaults.tenantCode] }
+					tenantCode
 				)
 				reportConfig = reportConfigWithDefaultOrgId
 			}
@@ -238,7 +238,7 @@ module.exports = class ReportsHelper {
 					report_code: reportCode,
 					organization_code: { [Op.in]: [orgCode, defaults.orgCode] },
 				},
-				{ [Op.in]: [tenantCode, defaults.tenantCode] }
+				tenantCode
 			)
 
 			if (reportQueryWithOrgId.length > 0) {
@@ -249,7 +249,7 @@ module.exports = class ReportsHelper {
 						report_code: reportCode,
 						organization_code: { [Op.in]: [orgCode, defaults.orgCode] },
 					},
-					{ [Op.in]: [tenantCode, defaults.tenantCode] }
+					tenantCode
 				)
 				reportQuery = reportQueryWithDefaultOrgId
 			}
@@ -452,7 +452,7 @@ module.exports = class ReportsHelper {
 					sessionModelName,
 					{},
 					tenantCode,
-					defaults.tenantCode
+					''
 				)
 
 				if (reportDataResult.report_type === common.REPORT_TABLE && resultWithoutPagination) {
@@ -487,7 +487,7 @@ module.exports = class ReportsHelper {
 							sessionModelName,
 							{},
 							tenantCode,
-							defaults.tenantCode
+							''
 						)
 
 						const filtersEntity = entityTypeFilters.result.reduce((acc, item) => {
@@ -517,7 +517,7 @@ module.exports = class ReportsHelper {
 							sessionModelName,
 							{},
 							tenantCode,
-							defaults.tenantCode
+							''
 						)
 
 						// Process the data

--- a/src/services/reports.js
+++ b/src/services/reports.js
@@ -39,7 +39,6 @@ module.exports = class ReportsHelper {
 			const report_filter = reportFilter === '' ? {} : { report_filter: reportFilter }
 
 			let organization_codes = []
-			let tenantCodes = []
 
 			const defaults = await getDefaults()
 			if (!defaults.orgCode)
@@ -64,7 +63,6 @@ module.exports = class ReportsHelper {
 
 			if (organizations.success && organizations.result) {
 				organization_codes = [...organizations.result.organizationCodes]
-				tenantCodes = [...organizations.result.tenantCodes]
 
 				if (organization_codes.length > 0) {
 					const defaults = await getDefaults()
@@ -85,8 +83,7 @@ module.exports = class ReportsHelper {
 						defaults.orgCode ? defaults.orgCode : '',
 						modelName,
 						report_filter,
-						tenantCodes,
-						''
+						tenantCode
 					)
 
 					if (getEntityTypesWithEntities.success && getEntityTypesWithEntities.result) {
@@ -196,7 +193,7 @@ module.exports = class ReportsHelper {
 			// Validate report permissions
 			const reportPermission = await reportMappingQueries.findReportRoleMappingByReportCode(
 				reportCode,
-				[tenantCode],
+				tenantCode,
 				[defaults.orgCode, orgCode]
 			)
 			if (!reportPermission || reportPermission.dataValues.role_title !== reportRole) {
@@ -451,8 +448,7 @@ module.exports = class ReportsHelper {
 					defaults.orgCode ? defaults.orgCode : '',
 					sessionModelName,
 					{},
-					tenantCode,
-					''
+					tenantCode
 				)
 
 				if (reportDataResult.report_type === common.REPORT_TABLE && resultWithoutPagination) {
@@ -486,8 +482,7 @@ module.exports = class ReportsHelper {
 							defaults.orgCode ? defaults.orgCode : '',
 							sessionModelName,
 							{},
-							tenantCode,
-							''
+							tenantCode
 						)
 
 						const filtersEntity = entityTypeFilters.result.reduce((acc, item) => {
@@ -516,8 +511,7 @@ module.exports = class ReportsHelper {
 							defaults.orgCode ? defaults.orgCode : '',
 							sessionModelName,
 							{},
-							tenantCode,
-							''
+							tenantCode
 						)
 
 						// Process the data

--- a/src/services/requestSessions.js
+++ b/src/services/requestSessions.js
@@ -859,7 +859,7 @@ async function emailForAcceptAndReject(
 		})
 
 	const orgCodes = [orgCode, defaults.orgCode]
-	const tenantCodes = [tenantCode, defaults.tenantCode]
+	const tenantCodes = [tenantCode]
 	// send mail to mentors on session creation if session created by manager
 	const templateData = await cacheHelper.notificationTemplates.get(tenantCode, orgCode, emailTemplateCode)
 

--- a/src/services/requestSessions.js
+++ b/src/services/requestSessions.js
@@ -270,7 +270,7 @@ module.exports = class requestSessionsHelper {
 				modelName,
 				'organization_code',
 				[],
-				[tenantCode]
+				tenantCode
 			)
 
 			const userDetailsMap = Object.fromEntries(oppositeUserDetails.map((u) => [u.user_id, u]))
@@ -859,7 +859,6 @@ async function emailForAcceptAndReject(
 		})
 
 	const orgCodes = [orgCode, defaults.orgCode]
-	const tenantCodes = [tenantCode]
 	// send mail to mentors on session creation if session created by manager
 	const templateData = await cacheHelper.notificationTemplates.get(tenantCode, orgCode, emailTemplateCode)
 

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -3234,7 +3234,7 @@ module.exports = class SessionsHelper {
 				common.sessionModelName,
 				'mentor_organization_id',
 				[],
-				[tenantCode]
+				tenantCode
 			)
 
 			await Promise.all(
@@ -3909,7 +3909,6 @@ module.exports = class SessionsHelper {
 				organization_code: organizationCode,
 				created_by: userId,
 				tenant_code: tenantCode,
-				defaultTenantCode: '',
 				defaultOrganizationCode: defaults.orgCode,
 			}
 
@@ -4174,7 +4173,6 @@ module.exports = class SessionsHelper {
 					removedSessionsDetail,
 					{ [Op.in]: [mentor.organization_code, defaults.orgCode] },
 					tenantCode,
-					tenantCode,
 					mentor.organization_code
 				)
 
@@ -4212,7 +4210,6 @@ module.exports = class SessionsHelper {
 				await adminService.unenrollAndNotifySessionAttendees(
 					removedSessionsDetail,
 					{ [Op.in]: [mentor.organization_code] },
-					tenantCode,
 					tenantCode,
 					mentor.organization_code
 				)

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -2578,7 +2578,8 @@ module.exports = class SessionsHelper {
 					{
 						status: common.LIVE_STATUS,
 						started_at: utils.utcFormat(),
-					}
+					},
+					tenantCode
 				)
 			}
 			if (session?.meeting_info?.link) {

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -3902,7 +3902,7 @@ module.exports = class SessionsHelper {
 				organization_code: organizationCode,
 				created_by: userId,
 				tenant_code: tenantCode,
-				defaultTenantCode: defaults.tenantCode,
+				defaultTenantCode: '',
 				defaultOrganizationCode: defaults.orgCode,
 			}
 
@@ -4166,7 +4166,7 @@ module.exports = class SessionsHelper {
 				await adminService.unenrollAndNotifySessionAttendees(
 					removedSessionsDetail,
 					{ [Op.in]: [mentor.organization_code, defaults.orgCode] },
-					{ [Op.in]: [tenantCode, defaults.tenantCode] },
+					tenantCode,
 					tenantCode,
 					mentor.organization_code
 				)
@@ -4205,7 +4205,7 @@ module.exports = class SessionsHelper {
 				await adminService.unenrollAndNotifySessionAttendees(
 					removedSessionsDetail,
 					{ [Op.in]: [mentor.organization_code] },
-					{ [Op.in]: [tenantCode] },
+					tenantCode,
 					tenantCode,
 					mentor.organization_code
 				)

--- a/src/services/tenant.js
+++ b/src/services/tenant.js
@@ -114,7 +114,7 @@ module.exports = class TenantService {
 			await replicateResource({
 				label: 'Forms',
 				fetchSource: () =>
-					FormQueries.findFormsByFilter({ organization_code: defaultOrgCode }, [defaultTenantCode]),
+					FormQueries.findFormsByFilter({ organization_code: defaultOrgCode }, defaultTenantCode),
 				transform: baseTransform({ organization_id: newOrgIdStr, version: 0 }),
 				bulkCreate: (items, opts) => FormQueries.bulkCreate(items, newTenantCode, opts),
 				transaction,
@@ -123,10 +123,10 @@ module.exports = class TenantService {
 			// ── 3. Entity Types ───────────────────────────────────────────────────
 			const entityTypeIdMap = await replicateWithIdMap({
 				label: 'Entity types',
-				fetchSource: () => EntityTypeQueries.findAllEntityTypes([defaultOrgCode], [defaultTenantCode], null),
+				fetchSource: () => EntityTypeQueries.findAllEntityTypes([defaultOrgCode], defaultTenantCode, null),
 				transform: baseTransform({ organization_id: newOrgIdStr, parent_id: null }),
 				bulkCreate: (items, opts) => EntityTypeQueries.bulkCreate(items, newTenantCode, opts),
-				fetchExisting: () => EntityTypeQueries.findAllEntityTypes([defaultOrgCode], [newTenantCode], null),
+				fetchExisting: () => EntityTypeQueries.findAllEntityTypes([defaultOrgCode], newTenantCode, null),
 				matchKey: (oldET) => (c) => c.value === oldET.value && c.organization_code === oldET.organization_code,
 				transaction,
 			})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Enforced strict tenant isolation: removed default-tenant fallback logic so queries and filters now use only the request tenant (tenantCode).
- Replaced multi-tenant Op.in filters (tenantCode + defaults.tenantCode) with single-tenant tenantCode across entity types, forms, notifications, rules, entities, reports, cache helpers, availability, and related modules.
- Cache helpers no longer fetch/merge default-tenant data; caches return only user-context results.
- Service-layer updates: entity, entity-type, form, notification, session, mentor/mentee, admin, reports, availability, and other services now operate with single-tenant scoping.
- DB/query helper changes: where clauses simplified to accept a single tenantCode; organization_code filter omitted when orgCodes is empty.
- Data-shape change: convertEntitiesForFilter now includes organization_code in output objects.
- Authenticator middleware: assigns process.env.DEFAULT_TENANT_CODE to req.decodedToken.tenant_code when missing (logged); otherwise tenant resolution is strict.
- Rollout/migration note: breaking-change risk for consumers depending on default-tenant fallback. Default data will be replicated per tenant in a separate PR (to be merged before this change). Tests and detailed migration/CHANGELOG updates deferred to a follow-up release.

| Author | Lines Added | Lines Removed |
|--------|-----------:|-------------:|
| borkarsaish65 | 72 | 263 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->