### PR TITLE
SANITY BUG 4513

### DIFF
--- a/src/database/queries/notificationTemplate.js
+++ b/src/database/queries/notificationTemplate.js
@@ -210,19 +210,12 @@ module.exports = class NotificationTemplateData {
 			if (!results || results.length === 0) return null
 			const preferredOrg = normalizedOrgCodes[0]
 			const preferredTenant = normalizedTenantCodes[0]
-			const score = (r) => {
-				if (
-					preferredOrg &&
-					preferredTenant &&
-					r.organization_code === preferredOrg &&
-					r.tenant_code === preferredTenant
-				)
-					return 3
-				if (preferredOrg && r.organization_code === preferredOrg) return 2
-				if (preferredTenant && r.tenant_code === preferredTenant) return 1
-				return 0
-			}
-			return [...results].sort((a, b) => score(b) - score(a))[0]
+			return (
+				results.find((r) => r.organization_code === preferredOrg && r.tenant_code === preferredTenant) ||
+				results.find((r) => r.organization_code === preferredOrg) ||
+				results.find((r) => r.tenant_code === preferredTenant) ||
+				results[0]
+			)
 		} catch (error) {
 			return null
 		}
@@ -245,19 +238,12 @@ module.exports = class NotificationTemplateData {
 			if (!results || results.length === 0) return null
 			const preferredOrg = normalizedOrgCodes[0]
 			const preferredTenant = normalizedTenantCodes[0]
-			const score = (r) => {
-				if (
-					preferredOrg &&
-					preferredTenant &&
-					r.organization_code === preferredOrg &&
-					r.tenant_code === preferredTenant
-				)
-					return 3
-				if (preferredOrg && r.organization_code === preferredOrg) return 2
-				if (preferredTenant && r.tenant_code === preferredTenant) return 1
-				return 0
-			}
-			return [...results].sort((a, b) => score(b) - score(a))[0]
+			return (
+				results.find((r) => r.organization_code === preferredOrg && r.tenant_code === preferredTenant) ||
+				results.find((r) => r.organization_code === preferredOrg) ||
+				results.find((r) => r.tenant_code === preferredTenant) ||
+				results[0]
+			)
 		} catch (error) {
 			return null
 		}

--- a/src/database/queries/notificationTemplate.js
+++ b/src/database/queries/notificationTemplate.js
@@ -172,14 +172,14 @@ module.exports = class NotificationTemplateData {
 
 			// Compose template with header and footer
 			if (selectedTemplate && selectedTemplate.email_header) {
-				const header = await this.getEmailHeader(selectedTemplate.email_header)
+				const header = await this.getEmailHeader(selectedTemplate.email_header, tenantCodes, orgCodes)
 				if (header && header.body) {
 					selectedTemplate.body = header.body + selectedTemplate.body
 				}
 			}
 
 			if (selectedTemplate && selectedTemplate.email_footer) {
-				const footer = await this.getEmailFooter(selectedTemplate.email_footer)
+				const footer = await this.getEmailFooter(selectedTemplate.email_footer, tenantCodes, orgCodes)
 				if (footer && footer.body) {
 					selectedTemplate.body += footer.body
 				}
@@ -193,31 +193,55 @@ module.exports = class NotificationTemplateData {
 		}
 	}
 
-	static async getEmailHeader(headerCode) {
+	static async getEmailHeader(headerCode, tenantCodes = [], orgCodes = []) {
 		try {
-			return await NotificationTemplate.findOne({
-				where: {
-					code: headerCode,
-					type: 'emailHeader',
-					status: 'active',
-				},
-				raw: true,
-			})
+			const where = {
+				code: headerCode,
+				type: 'emailHeader',
+				status: 'active',
+			}
+			if (tenantCodes.length > 0) where.tenant_code = { [Op.in]: tenantCodes }
+			if (orgCodes.length > 0) where.organization_code = { [Op.in]: orgCodes }
+			const results = await NotificationTemplate.findAll({ where, raw: true })
+			if (!results || results.length === 0) return null
+			return (
+				results.find(
+					(h) =>
+						orgCodes[0] &&
+						h.organization_code === orgCodes[0] &&
+						tenantCodes[0] &&
+						h.tenant_code === tenantCodes[0]
+				) ||
+				results.find((h) => orgCodes[0] && h.organization_code === orgCodes[0]) ||
+				results[0]
+			)
 		} catch (error) {
 			return null
 		}
 	}
 
-	static async getEmailFooter(footerCode) {
+	static async getEmailFooter(footerCode, tenantCodes = [], orgCodes = []) {
 		try {
-			return await NotificationTemplate.findOne({
-				where: {
-					code: footerCode,
-					type: 'emailFooter',
-					status: 'active',
-				},
-				raw: true,
-			})
+			const where = {
+				code: footerCode,
+				type: 'emailFooter',
+				status: 'active',
+			}
+			if (tenantCodes.length > 0) where.tenant_code = { [Op.in]: tenantCodes }
+			if (orgCodes.length > 0) where.organization_code = { [Op.in]: orgCodes }
+			const results = await NotificationTemplate.findAll({ where, raw: true })
+			if (!results || results.length === 0) return null
+			return (
+				results.find(
+					(h) =>
+						orgCodes[0] &&
+						h.organization_code === orgCodes[0] &&
+						tenantCodes[0] &&
+						h.tenant_code === tenantCodes[0]
+				) ||
+				results.find((h) => orgCodes[0] && h.organization_code === orgCodes[0]) ||
+				results[0]
+			)
 		} catch (error) {
 			return null
 		}

--- a/src/database/queries/notificationTemplate.js
+++ b/src/database/queries/notificationTemplate.js
@@ -195,26 +195,34 @@ module.exports = class NotificationTemplateData {
 
 	static async getEmailHeader(headerCode, tenantCodes = [], orgCodes = []) {
 		try {
+			const normalizedTenantCodes = Array.isArray(tenantCodes)
+				? tenantCodes.filter(Boolean)
+				: [tenantCodes].filter(Boolean)
+			const normalizedOrgCodes = Array.isArray(orgCodes) ? orgCodes.filter(Boolean) : [orgCodes].filter(Boolean)
 			const where = {
 				code: headerCode,
 				type: 'emailHeader',
 				status: 'active',
 			}
-			if (tenantCodes.length > 0) where.tenant_code = { [Op.in]: tenantCodes }
-			if (orgCodes.length > 0) where.organization_code = { [Op.in]: orgCodes }
+			if (normalizedTenantCodes.length > 0) where.tenant_code = { [Op.in]: normalizedTenantCodes }
+			if (normalizedOrgCodes.length > 0) where.organization_code = { [Op.in]: normalizedOrgCodes }
 			const results = await NotificationTemplate.findAll({ where, raw: true })
 			if (!results || results.length === 0) return null
-			return (
-				results.find(
-					(h) =>
-						orgCodes[0] &&
-						h.organization_code === orgCodes[0] &&
-						tenantCodes[0] &&
-						h.tenant_code === tenantCodes[0]
-				) ||
-				results.find((h) => orgCodes[0] && h.organization_code === orgCodes[0]) ||
-				results[0]
-			)
+			const preferredOrg = normalizedOrgCodes[0]
+			const preferredTenant = normalizedTenantCodes[0]
+			const score = (r) => {
+				if (
+					preferredOrg &&
+					preferredTenant &&
+					r.organization_code === preferredOrg &&
+					r.tenant_code === preferredTenant
+				)
+					return 3
+				if (preferredOrg && r.organization_code === preferredOrg) return 2
+				if (preferredTenant && r.tenant_code === preferredTenant) return 1
+				return 0
+			}
+			return [...results].sort((a, b) => score(b) - score(a))[0]
 		} catch (error) {
 			return null
 		}
@@ -222,26 +230,34 @@ module.exports = class NotificationTemplateData {
 
 	static async getEmailFooter(footerCode, tenantCodes = [], orgCodes = []) {
 		try {
+			const normalizedTenantCodes = Array.isArray(tenantCodes)
+				? tenantCodes.filter(Boolean)
+				: [tenantCodes].filter(Boolean)
+			const normalizedOrgCodes = Array.isArray(orgCodes) ? orgCodes.filter(Boolean) : [orgCodes].filter(Boolean)
 			const where = {
 				code: footerCode,
 				type: 'emailFooter',
 				status: 'active',
 			}
-			if (tenantCodes.length > 0) where.tenant_code = { [Op.in]: tenantCodes }
-			if (orgCodes.length > 0) where.organization_code = { [Op.in]: orgCodes }
+			if (normalizedTenantCodes.length > 0) where.tenant_code = { [Op.in]: normalizedTenantCodes }
+			if (normalizedOrgCodes.length > 0) where.organization_code = { [Op.in]: normalizedOrgCodes }
 			const results = await NotificationTemplate.findAll({ where, raw: true })
 			if (!results || results.length === 0) return null
-			return (
-				results.find(
-					(h) =>
-						orgCodes[0] &&
-						h.organization_code === orgCodes[0] &&
-						tenantCodes[0] &&
-						h.tenant_code === tenantCodes[0]
-				) ||
-				results.find((h) => orgCodes[0] && h.organization_code === orgCodes[0]) ||
-				results[0]
-			)
+			const preferredOrg = normalizedOrgCodes[0]
+			const preferredTenant = normalizedTenantCodes[0]
+			const score = (r) => {
+				if (
+					preferredOrg &&
+					preferredTenant &&
+					r.organization_code === preferredOrg &&
+					r.tenant_code === preferredTenant
+				)
+					return 3
+				if (preferredOrg && r.organization_code === preferredOrg) return 2
+				if (preferredTenant && r.tenant_code === preferredTenant) return 1
+				return 0
+			}
+			return [...results].sort((a, b) => score(b) - score(a))[0]
 		} catch (error) {
 			return null
 		}

--- a/src/database/queries/sessions.js
+++ b/src/database/queries/sessions.js
@@ -60,7 +60,7 @@ exports.findOne = async (filter, tenantCode, options = {}) => {
 
 exports.findById = async (id, tenantCode) => {
 	try {
-		return await Session.findOne({ where: { id, tenant_code: tenantCode } })
+		return await Session.findOne({ where: { id, tenant_code: tenantCode }, raw: true })
 	} catch (error) {
 		return error
 	}

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -1538,39 +1538,16 @@ const notificationTemplates = {
 				}
 			}
 
-			// Step 3: Cache miss - query database with prioritized fallback logic
+			// Step 3: Cache miss - query database with header/footer injection
+			// Uses findOneEmailTemplate so email_header (logo) and email_footer are composed into body
 
 			let templateFromDb = null
 			try {
-				// Try user tenant/org first
-				templateFromDb = await notificationTemplateQueries.findOne(
-					{
-						code: templateCode,
-						organization_code: orgCode,
-						type: 'email',
-						status: 'active',
-					},
-					tenantCode
+				templateFromDb = await notificationTemplateQueries.findOneEmailTemplate(
+					templateCode,
+					[orgCode, defaults.orgCode],
+					[tenantCode, defaults.tenantCode]
 				)
-
-				// If not found and defaults are different, try defaults
-				if (
-					!templateFromDb &&
-					defaults &&
-					defaults.orgCode &&
-					defaults.tenantCode &&
-					(defaults.tenantCode !== tenantCode || defaults.orgCode !== orgCode)
-				) {
-					templateFromDb = await notificationTemplateQueries.findOne(
-						{
-							code: templateCode,
-							organization_code: defaults.orgCode,
-							type: 'email',
-							status: 'active',
-						},
-						defaults.tenantCode
-					)
-				}
 
 				if (templateFromDb) {
 					console.log(

--- a/src/services/connections.js
+++ b/src/services/connections.js
@@ -541,8 +541,8 @@ module.exports = class ConnectionHelper {
 				{
 					attributes: ['name', 'email', 'user_id'],
 				},
-				false,
-				tenantCode
+				tenantCode,
+				false
 			)
 
 			// Get mentor details using getCacheOnly first, then fallback to database query
@@ -624,8 +624,8 @@ module.exports = class ConnectionHelper {
 				{
 					attributes: ['name', 'email', 'user_id'],
 				},
-				false,
-				tenantCode
+				tenantCode,
+				false
 			)
 
 			// Get mentor details using getCacheOnly first, then fallback to database query

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1179,6 +1179,8 @@ module.exports = class SessionsHelper {
 					const needsTemplateData =
 						method == common.DELETE_METHOD || isSessionReschedule || (isSessionDataChanged && notifyUser)
 					if (needsTemplateData && !templateData) return
+					if ((preResourceSendEmail || postResourceSendEmail) && !preOrPostEmailTemplate) return
+					if (mentorUpdated && !mentorChangedTemplate) return
 
 					if (method == common.DELETE_METHOD) {
 						let duration = moment.duration(

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1176,6 +1176,10 @@ module.exports = class SessionsHelper {
 
 				// send mail associated with action to session mentees
 				sessionAttendees.forEach(async (attendee) => {
+					const needsTemplateData =
+						method == common.DELETE_METHOD || isSessionReschedule || (isSessionDataChanged && notifyUser)
+					if (needsTemplateData && !templateData) return
+
 					if (method == common.DELETE_METHOD) {
 						let duration = moment.duration(
 							moment.unix(sessionDetail.end_date).diff(moment.unix(sessionDetail.start_date))
@@ -1210,7 +1214,6 @@ module.exports = class SessionsHelper {
 						// send email only if notify user is true
 						if (notifyUser) await kafkaCommunication.pushEmailToKafka(payload)
 					} else if (isSessionReschedule || (isSessionDataChanged && notifyUser)) {
-						if (!templateData) return
 						// Find old duration of session
 						let oldDuration = moment.duration(
 							moment.unix(sessionDetail.end_date).diff(moment.unix(sessionDetail.start_date))

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1176,14 +1176,6 @@ module.exports = class SessionsHelper {
 
 				// send mail associated with action to session mentees
 				sessionAttendees.forEach(async (attendee) => {
-					if (
-						!templateData &&
-						(method == common.DELETE_METHOD || isSessionReschedule || (isSessionDataChanged && notifyUser))
-					)
-						return
-					if (!preOrPostEmailTemplate && (preResourceSendEmail || postResourceSendEmail)) return
-					if (!mentorChangedTemplate && mentorUpdated) return
-
 					if (method == common.DELETE_METHOD) {
 						let duration = moment.duration(
 							moment.unix(sessionDetail.end_date).diff(moment.unix(sessionDetail.start_date))

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1210,6 +1210,7 @@ module.exports = class SessionsHelper {
 						// send email only if notify user is true
 						if (notifyUser) await kafkaCommunication.pushEmailToKafka(payload)
 					} else if (isSessionReschedule || (isSessionDataChanged && notifyUser)) {
+						if (!templateData) return
 						// Find old duration of session
 						let oldDuration = moment.duration(
 							moment.unix(sessionDetail.end_date).diff(moment.unix(sessionDetail.start_date))
@@ -3507,7 +3508,7 @@ module.exports = class SessionsHelper {
 			const enrollPromises = mentees.map((menteeData) =>
 				this.enroll(
 					sessionId,
-					{ user_id: menteeData.user_id },
+					{ user_id: menteeData.user_id, email: menteeData.email, name: menteeData.name },
 					timeZone,
 					menteeData.is_mentor,
 					false,
@@ -3610,6 +3611,7 @@ module.exports = class SessionsHelper {
 			}
 
 			const templateData = await cacheHelper.notificationTemplates.get(tenantCode, orgCode, templateCode)
+			if (!templateData) return null
 
 			// Construct data
 			const payload = {

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1176,11 +1176,13 @@ module.exports = class SessionsHelper {
 
 				// send mail associated with action to session mentees
 				sessionAttendees.forEach(async (attendee) => {
-					const needsTemplateData =
-						method == common.DELETE_METHOD || isSessionReschedule || (isSessionDataChanged && notifyUser)
-					if (needsTemplateData && !templateData) return
-					if ((preResourceSendEmail || postResourceSendEmail) && !preOrPostEmailTemplate) return
-					if (mentorUpdated && !mentorChangedTemplate) return
+					if (
+						!templateData &&
+						(method == common.DELETE_METHOD || isSessionReschedule || (isSessionDataChanged && notifyUser))
+					)
+						return
+					if (!preOrPostEmailTemplate && (preResourceSendEmail || postResourceSendEmail)) return
+					if (!mentorChangedTemplate && mentorUpdated) return
 
 					if (method == common.DELETE_METHOD) {
 						let duration = moment.duration(


### PR DESCRIPTION
Enhance notification template queries to support tenant and organization code filtering in getEmailHeader and getEmailFooter methods. Update cacheHelper to utilize new query methods for improved email template retrieval. Modify session handling to include additional user details and ensure proper template data checks before processing notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Add tenant and organization code filtering to notification template queries; getEmailHeader() and getEmailFooter() accept tenantCodes and orgCodes arrays.
- Prioritize template selection by exact tenant+org match, then org, then tenant, then default.
- Compose email header/footer using tenant/org-aware lookups during template assembly.
- Consolidate email-template retrieval in cacheHelper to use findOneEmailTemplate(...) instead of separate query + fallback logic.
- Add guards to skip/abort email processing when required template data is missing (reschedule, pre/post resource, mentor-change flows).
- Include additional user details in session handling and return session rows as plain objects via raw: true.
- Expand addMentees enrollment payload to include email and name; perform bulk enrollment with Promise.allSettled and aggregate results.
- Add guard in pushSessionRelatedMentorEmailToKafka to avoid building/sending mentor emails when template data is absent.
- Fix argument ordering in several connection-related calls to correctly pass tenantCode vs boolean flags.

## Lines Changed by Author

| Author | Added | Removed |
|--------|------:|--------:|
| sumanvpacewisdom | 62 | 56 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->