### PR TITLE
Add organization_id condition to prevent duplication in OrganizationAndEntityTypePolicyHelper - bug 4572

### DIFF
--- a/src/helpers/getOrgIdAndEntityTypewithEntitiesBasedOnPolicy.js
+++ b/src/helpers/getOrgIdAndEntityTypewithEntitiesBasedOnPolicy.js
@@ -188,6 +188,7 @@ module.exports = class OrganizationAndEntityTypePolicyHelper {
 										],
 									},
 								],
+								organization_id: { [Op.ne]: orgExtension.organization_id },
 								tenant_code: tenantCode,
 							},
 							{


### PR DESCRIPTION
Add organization_id condition to prevent duplication in OrganizationAndEntityTypePolicyHelper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Added organization_id condition to prevent duplication in OrganizationAndEntityTypePolicyHelper
- Excludes current organization_id from related organizations query when fetching additional organizations for ASSOCIATED/ALL visibility policies
- Prevents duplicate organization entries in the organization information array for mentee, mentor, and session filtering based on visibility policies

## Changes by Author

| Author | Added | Removed |
|--------|-------|---------|
| sumanvpacewisdom | 317 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->