### PR TITLE
Add new admin routes for cache management in elevate-mentoring

### DIFF
--- a/interface-routes/elevate-mentoring.json
+++ b/interface-routes/elevate-mentoring.json
@@ -2711,6 +2711,58 @@
 			}
 		},
 		{
+			"sourceRoute": "/mentoring/v1/admin/getCacheStats",
+			"type": "GET",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "mentoring",
+					"packageName": "elevate-mentoring"
+				}
+			]
+		},
+		{
+			"sourceRoute": "/mentoring/v1/admin/clearCache",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "mentoring",
+					"packageName": "elevate-mentoring"
+				}
+			]
+		},
+		{
+			"sourceRoute": "/mentoring/v1/admin/warmUpCache",
+			"type": "GET",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "mentoring",
+					"packageName": "elevate-mentoring"
+				}
+			]
+		},
+		{
+			"sourceRoute": "/mentoring/v1/admin/getCacheHealth",
+			"type": "GET",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "mentoring",
+					"packageName": "elevate-mentoring"
+				}
+			]
+		},
+		{
 			"sourceRoute": "/mentoring/v1/mentors/list",
 			"type": "GET",
 			"priority": "MUST_HAVE",


### PR DESCRIPTION
This update introduces four new routes: getCacheStats, clearCache, warmUpCache, and getCacheHealth, all marked as MUST_HAVE. These routes enhance the administrative capabilities for cache management within the mentoring module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Added four new administrative cache management routes under `/mentoring/v1/admin`:
  - `GET /mentoring/v1/admin/getCacheStats` - Retrieve cache statistics
  - `POST /mentoring/v1/admin/clearCache` - Clear cache
  - `GET /mentoring/v1/admin/warmUpCache` - Warm up cache
  - `GET /mentoring/v1/admin/getCacheHealth` - Check cache health status
- All routes marked as MUST_HAVE priority for administrative operations
- Routes configured with non-sequential, non-orchestrated execution targeting the elevate-mentoring package

## Contributor Statistics

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| sumanvpacewisdom | 52 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->