### PR TITLE
fix: cache invalidation and org priority bugs in forms

### DIFF
--- a/src/services/form.js
+++ b/src/services/form.js
@@ -29,7 +29,16 @@ module.exports = class FormsHelper {
 			bodyData['organization_code'] = orgCode
 			const form = await formQueries.createForm(bodyData, tenantCode, orgCode)
 
-			await KafkaProducer.clearInternalCache('formVersion')
+			//			await KafkaProducer.clearInternalCache('formVersion')
+
+			// Invalidate cache so stale fallback (default org) is not served
+			try {
+				if (bodyData.type && bodyData.sub_type) {
+					await cacheHelper.forms.delete(tenantCode, orgCode, bodyData.type, bodyData.sub_type)
+				}
+			} catch (cacheError) {
+				console.error('Failed to invalidate form cache:', cacheError)
+			}
 
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
@@ -185,8 +194,8 @@ module.exports = class FormsHelper {
 				})
 			}
 
-			// Business logic: Prefer current tenant over default tenant
-			const form = forms.find((f) => f.tenant_code === tenantCode) || forms[0]
+			// Business logic: Prefer current org over default org
+			const form = forms.find((f) => f.organization_code === orgCode) || forms[0]
 
 			// Cache the result if it was searched by type and subtype
 			if (!id && bodyData?.type && bodyData?.sub_type) {
@@ -240,7 +249,10 @@ module.exports = class FormsHelper {
 									)
 
 									if (completeFormData && completeFormData.length > 0) {
-										const formData = completeFormData[0]
+										// Prefer custom org form over default org form
+										const formData =
+											completeFormData.find((f) => f.organization_code !== defaults.orgCode) ||
+											completeFormData[0]
 										if (formData.sub_type) {
 											await cacheHelper.forms.set(
 												tenantCode,


### PR DESCRIPTION
- Add cache invalidation on create to prevent stale fallback (default org) data
- Fix read() priority to prefer user's org over default org (was using tenant_code, should be organization_code)
- Fix readAllFormsVersion() to cache user org form over default org form when both exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Cache invalidation on form creation:** Added cache invalidation after successful form creation to prevent stale default organization data from being served
- **Fixed org priority in form read:** Updated `read()` method to prioritize user's organization form over default organization form by using `organization_code` instead of `tenant_code` for comparison
- **Fixed org priority in form version caching:** Updated `readAllFormsVersion()` to cache user organization forms over default organization forms when both exist, preferring custom organization entries

## Lines Changed by Author

| Author | Lines Added | Lines Removed |
|--------|------------|---------------|
| borkarsaish65 | 15 | 3 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->