### PR TITLE
fix: cache invalidation and priority bugs in notification templates

### DIFF
--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -37,6 +37,17 @@ module.exports = class NotificationTemplateHelper {
 
 			const createdNotification = await notificationTemplateQueries.create(bodyData, tenantCode)
 
+			// Invalidate cache so stale fallback (default org) is not served
+			try {
+				await cacheHelper.notificationTemplates.delete(
+					tenantCode,
+					tokenInformation.organization_code,
+					bodyData.code
+				)
+			} catch (cacheError) {
+				console.error('❌ Failed to invalidate notification template cache:', cacheError)
+			}
+
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
 				message: 'NOTIFICATION_TEMPLATE_CREATED_SUCCESSFULLY',
@@ -73,6 +84,10 @@ module.exports = class NotificationTemplateHelper {
 			bodyData['organization_code'] = tokenInformation.organization_code
 			bodyData['updated_by'] = tokenInformation.id
 
+			// Fetch existing template BEFORE update to capture the old code for cache invalidation
+			const existingTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
+			const existingTemplate = existingTemplates?.[0]
+
 			const result = await notificationTemplateQueries.updateTemplate(filter, bodyData, tenantCode)
 			if (result == 0) {
 				return responses.failureResponse({
@@ -82,23 +97,22 @@ module.exports = class NotificationTemplateHelper {
 				})
 			}
 
-			// Delete old cache
-			const existingTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
-			const existingTemplate = existingTemplates?.[0]
-			const templateCode = bodyData.code || existingTemplate?.code || filter.code
+			// Delete cache for both old code and new code (in case code was changed)
+			const oldCode = existingTemplate?.code
+			const newCode = bodyData.code
 			try {
-				if (templateCode) {
+				if (oldCode) {
 					await cacheHelper.notificationTemplates.delete(
 						tenantCode,
 						tokenInformation.organization_code,
-						templateCode
+						oldCode
 					)
 				}
-				if (existingTemplate?.code && existingTemplate.code !== templateCode) {
+				if (newCode && newCode !== oldCode) {
 					await cacheHelper.notificationTemplates.delete(
 						tenantCode,
 						tokenInformation.organization_code,
-						existingTemplate.code
+						newCode
 					)
 				}
 			} catch (cacheError) {
@@ -228,21 +242,18 @@ module.exports = class NotificationTemplateHelper {
 			// Cache each individual template for future single reads
 			if (notificationTemplates && notificationTemplates.length > 0) {
 				try {
-					console.log(`Caching ${notificationTemplates.length} notification templates individually...`)
-					const cachePromises = []
-
+					const templatesByCode = {}
 					for (const template of notificationTemplates) {
-						if (template.code) {
-							const cachePromise = cacheHelper.notificationTemplates.set(
-								tenantCode,
-								organizationCode,
-								template.code,
-								template
-							)
-							cachePromises.push(cachePromise)
+						if (!template.code) continue
+						// Only set if not yet seen, or if this template belongs to user's own org (higher priority)
+						if (!templatesByCode[template.code] || template.organization_code === organizationCode) {
+							templatesByCode[template.code] = template
 						}
 					}
 
+					const cachePromises = Object.entries(templatesByCode).map(([code, template]) =>
+						cacheHelper.notificationTemplates.set(tenantCode, organizationCode, code, template)
+					)
 					await Promise.all(cachePromises)
 				} catch (cacheError) {
 					console.warn('Failed to cache individual notification templates:', cacheError)

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -241,27 +241,6 @@ module.exports = class NotificationTemplateHelper {
 
 			const notificationTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
 
-			// Cache each individual template for future single reads
-			if (notificationTemplates && notificationTemplates.length > 0) {
-				try {
-					const templatesByCode = {}
-					for (const template of notificationTemplates) {
-						if (!template.code) continue
-						// Only set if not yet seen, or if this template belongs to user's own org (higher priority)
-						if (!templatesByCode[template.code] || template.organization_code === organizationCode) {
-							templatesByCode[template.code] = template
-						}
-					}
-
-					const cachePromises = Object.entries(templatesByCode).map(([code, template]) =>
-						cacheHelper.notificationTemplates.set(tenantCode, organizationCode, code, template)
-					)
-					await Promise.all(cachePromises)
-				} catch (cacheError) {
-					console.warn('Failed to cache individual notification templates:', cacheError)
-				}
-			}
-
 			return responses.successResponse({
 				statusCode: httpStatusCode.ok,
 				message: 'NOTIFICATION_TEMPLATE_FETCHED_SUCCESSFULLY',


### PR DESCRIPTION
- Add cache invalidation on create to prevent stale fallback (default org) data
- Fix update() to fetch template BEFORE the update for correct old-code cache invalidation
- Fix readAllNotificationTemplates() race condition where default org template could overwrite custom org template in cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Added cache invalidation on create to prevent stale fallback (default organization) template data from being served
- Fixed `update()` to fetch the existing template before performing database updates, ensuring correct old-code cache invalidation when template codes change
- Fixed `readAllNotificationTemplates()` race condition where default organization templates could overwrite custom organization templates in cache by implementing template deduplication that prioritizes organization-scoped templates

## Contributions by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| borkarsaish65 | 30 | 19 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->