### PR TITLE
default values from config.json file for authentication

### DIFF
--- a/src/middlewares/authenticator.js
+++ b/src/middlewares/authenticator.js
@@ -110,7 +110,7 @@ module.exports = async function (req, res, next) {
 
 						decodedToken[organizationKey] = orgId
 						const resolvedRolePath = resolvePathTemplate(rolePathTemplate, decodedToken)
-						const roles = getNestedValue(decodedToken, resolvedRolePath) ?? defaultVal ?? []
+						const roles = [...(getNestedValue(decodedToken, resolvedRolePath) ?? []), ...(defaultVal ?? [])]
 						req.decodedToken[key] = roles
 						continue
 					}

--- a/src/middlewares/authenticator.js
+++ b/src/middlewares/authenticator.js
@@ -80,6 +80,12 @@ module.exports = async function (req, res, next) {
 				...decodedToken.data,
 			}
 		} else {
+			// Resolve organization_id path once — used by both 'roles' and 'organization_code' blocks
+			const orgIdPath =
+				typeof configData[organizationKey] === 'object'
+					? configData[organizationKey].path
+					: configData[organizationKey]
+
 			// Iterate through each key in the config object
 			for (let key in configData) {
 				if (configData.hasOwnProperty(key)) {
@@ -97,10 +103,6 @@ module.exports = async function (req, res, next) {
 						continue
 					}
 					if (key === 'roles') {
-						const orgIdPath =
-							typeof configData[organizationKey] === 'object'
-								? configData[organizationKey].path
-								: configData[organizationKey]
 						let orgId = getOrgId(req.headers, decodedToken, orgIdPath)
 
 						// Now extract roles using fully dynamic path
@@ -114,10 +116,6 @@ module.exports = async function (req, res, next) {
 					}
 
 					if (key === 'organization_code') {
-						const orgIdPath =
-							typeof configData[organizationKey] === 'object'
-								? configData[organizationKey].path
-								: configData[organizationKey]
 						let orgId = getOrgId(req.headers, decodedToken, orgIdPath)
 
 						// Now extract roles using fully dynamic path

--- a/src/middlewares/authenticator.js
+++ b/src/middlewares/authenticator.js
@@ -112,13 +112,17 @@ module.exports = async function (req, res, next) {
 
 						decodedToken[organizationKey] = orgId
 						const resolvedRolePath = resolvePathTemplate(rolePathTemplate, decodedToken)
-						const roles = [...(getNestedValue(decodedToken, resolvedRolePath) ?? []), ...(defaultVal ?? [])]
+						//deduplicates roles if roles provided in the default config configuration
+						const extractedRoles = getNestedValue(decodedToken, resolvedRolePath) ?? []
+						const extractedTitles = new Set(extractedRoles.map((r) => r.title))
+						const uniqueDefaults = (defaultVal ?? []).filter((r) => !extractedTitles.has(r.title))
+						const roles = [...extractedRoles, ...uniqueDefaults]
 						req.decodedToken[key] = roles
 						continue
 					}
 
 					if (key === 'organization_code') {
-						let orgId = getOrgId(req.headers, decodedToken, orgIdPath)
+						let orgId = getOrgId(req.headers, decodedToken, orgIdPath, orgIdDefault)
 
 						// Now extract organization_code using fully dynamic path
 						const rolePathTemplate = pathStr

--- a/src/middlewares/authenticator.js
+++ b/src/middlewares/authenticator.js
@@ -118,7 +118,7 @@ module.exports = async function (req, res, next) {
 					if (key === 'organization_code') {
 						let orgId = getOrgId(req.headers, decodedToken, orgIdPath)
 
-						// Now extract roles using fully dynamic path
+						// Now extract organization_code using fully dynamic path
 						const rolePathTemplate = pathStr
 
 						decodedToken[organizationKey] = orgId

--- a/src/middlewares/authenticator.js
+++ b/src/middlewares/authenticator.js
@@ -85,6 +85,8 @@ module.exports = async function (req, res, next) {
 				typeof configData[organizationKey] === 'object'
 					? configData[organizationKey].path
 					: configData[organizationKey]
+			const orgIdDefault =
+				typeof configData[organizationKey] === 'object' ? configData[organizationKey].default : undefined
 
 			// Iterate through each key in the config object
 			for (let key in configData) {
@@ -98,12 +100,12 @@ module.exports = async function (req, res, next) {
 						keyValue = keyValue?.toString()
 					}
 					if (key === organizationKey) {
-						const orgId = getOrgId(req.headers, decodedToken, pathStr)
+						const orgId = getOrgId(req.headers, decodedToken, pathStr, orgIdDefault)
 						req.decodedToken[key] = orgId
 						continue
 					}
 					if (key === 'roles') {
-						let orgId = getOrgId(req.headers, decodedToken, orgIdPath)
+						let orgId = getOrgId(req.headers, decodedToken, orgIdPath, orgIdDefault)
 
 						// Now extract roles using fully dynamic path
 						const rolePathTemplate = pathStr
@@ -203,12 +205,12 @@ module.exports = async function (req, res, next) {
 	}
 }
 
-function getOrgId(headers, decodedToken, orgConfigData) {
+function getOrgId(headers, decodedToken, orgConfigData, defaultVal) {
 	if (headers['organization_id']) {
 		return (orgId = headers['organization_id'].toString())
 	} else {
 		const orgIdPath = orgConfigData
-		return (orgId = getNestedValue(decodedToken, orgIdPath)?.toString())
+		return (orgId = (getNestedValue(decodedToken, orgIdPath) ?? defaultVal)?.toString())
 	}
 }
 function getNestedValue(obj, path) {

--- a/src/middlewares/authenticator.js
+++ b/src/middlewares/authenticator.js
@@ -83,36 +83,49 @@ module.exports = async function (req, res, next) {
 			// Iterate through each key in the config object
 			for (let key in configData) {
 				if (configData.hasOwnProperty(key)) {
-					let keyValue = getNestedValue(decodedToken, configData[key])
+					const configEntry = configData[key]
+					const pathStr = typeof configEntry === 'object' ? configEntry.path : configEntry
+					const defaultVal = typeof configEntry === 'object' ? configEntry.default : undefined
+
+					let keyValue = getNestedValue(decodedToken, pathStr) ?? defaultVal
 					if (key === 'id') {
 						keyValue = keyValue?.toString()
 					}
 					if (key === organizationKey) {
-						req.decodedToken[key] = getOrgId(req.headers, decodedToken, configData[key])
+						const orgId = getOrgId(req.headers, decodedToken, pathStr)
+						req.decodedToken[key] = orgId
 						continue
 					}
 					if (key === 'roles') {
-						let orgId = getOrgId(req.headers, decodedToken, configData[organizationKey])
+						const orgIdPath =
+							typeof configData[organizationKey] === 'object'
+								? configData[organizationKey].path
+								: configData[organizationKey]
+						let orgId = getOrgId(req.headers, decodedToken, orgIdPath)
 
 						// Now extract roles using fully dynamic path
-						const rolePathTemplate = configData['roles']
+						const rolePathTemplate = pathStr
 
 						decodedToken[organizationKey] = orgId
 						const resolvedRolePath = resolvePathTemplate(rolePathTemplate, decodedToken)
-						const roles = getNestedValue(decodedToken, resolvedRolePath) || []
+						const roles = getNestedValue(decodedToken, resolvedRolePath) ?? defaultVal ?? []
 						req.decodedToken[key] = roles
 						continue
 					}
 
 					if (key === 'organization_code') {
-						let orgId = getOrgId(req.headers, decodedToken, configData[organizationKey])
+						const orgIdPath =
+							typeof configData[organizationKey] === 'object'
+								? configData[organizationKey].path
+								: configData[organizationKey]
+						let orgId = getOrgId(req.headers, decodedToken, orgIdPath)
 
 						// Now extract roles using fully dynamic path
-						const rolePathTemplate = configData['organization_code']
+						const rolePathTemplate = pathStr
 
 						decodedToken[organizationKey] = orgId
 						const resolvedOrgPath = resolvePathTemplate(rolePathTemplate, decodedToken)
-						const org = getNestedValue(decodedToken, resolvedOrgPath) || []
+						const org = getNestedValue(decodedToken, resolvedOrgPath) ?? defaultVal ?? []
 						req.decodedToken[key] = org
 						continue
 					}

--- a/src/sample.config.json
+++ b/src/sample.config.json
@@ -46,7 +46,6 @@
 		"name": "data.name",
 		"organization_id": "data.organization_ids[0]",
 		"organizations": "data.organizations",
-		"organization_code": "data.organizations[?organization_id={{organization_id}}].code",
 		"roles": {
 			"path": "data.organizations[?organization_id={{organization_id}}].roles",
 			"default": [{ "title": "mentee" }]

--- a/src/sample.config.json
+++ b/src/sample.config.json
@@ -44,9 +44,16 @@
 	"authTokenUserInformation": {
 		"id": "data.id",
 		"name": "data.name",
-		"roles": "data.organizations[?organization_id={{organization_id}}].roles",
 		"organization_id": "data.organization_ids[0]",
 		"organizations": "data.organizations",
-		"tenant_code": "data.tenant_code"
+		"organization_code": "data.organizations[?organization_id={{organization_id}}].code",
+		"roles": {
+			"path": "data.organizations[?organization_id={{organization_id}}].roles",
+			"default": [{ "title": "mentee" }]
+		},
+		"tenant_code": {
+			"path": "data.tenant_code",
+			"default": ""
+		}
 	}
 }

--- a/src/sample.config.json
+++ b/src/sample.config.json
@@ -47,7 +47,7 @@
 		"organization_id": "data.organization_ids[0]",
 		"organizations": "data.organizations",
 		"roles": {
-			"path": "data.organizations[?organization_id={{organization_id}}].roles",
+			"path": "data.organizations[?id={{organization_id}}].roles",
 			"default": [{ "title": "mentee" }]
 		},
 		"tenant_code": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Authenticator middleware now supports config entries as either path strings or objects with { path, default }.
- Organization config is normalized once (orgIdPath, orgIdDefault) and reused to derive per-entry pathStr and defaultVal for nested lookups.
- Extracted values use nullish coalescing with configured defaults:
  - roles extraction concatenates extracted roles with configured defaults when extraction yields nothing.
  - organization_code falls back to the configured default.
- getOrgId signature extended to accept a default and falls back to it before stringifying.
- Sample config updated: authTokenUserInformation.roles and authTokenUserInformation.tenant_code changed from path strings to { path, default } objects (roles default: [{ "title": "mentee" }], tenant_code default: "").

## Lines Changed by Author

| Author | Lines Added | Lines Removed |
|--------|-------------:|--------------:|
| borkarsaish65 | 32 | 13 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->