### PR TITLE
Fix/default org form cache invalidation

### DIFF
--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -825,7 +825,7 @@ const forms = {
 	 * Used when the default org updates a form — other orgs may have cached
 	 * the default org's form data under their own org key via fallback logic.
 	 */
-	async deleteAcrossAllOrgs(tenantCode, type, subtype) {
+	async deleteFormsAcrossAllOrgs(tenantCode, type, subtype) {
 		const pattern = `tenant:${tenantCode}:org:*:forms:${type}:${subtype}`
 		const result = await scanAndDelete(pattern)
 		return result

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -723,7 +723,6 @@ const forms = {
 	 */
 	async get(tenantCode, orgCode, type, subtype) {
 		try {
-			console.log('Entering......')
 			const compositeId = `${type}:${subtype}`
 			const useInternal = nsUseInternal('forms')
 
@@ -769,8 +768,6 @@ const forms = {
 				return null
 			}
 
-			console.log(formFromDb, '<<--formFromDb 771')
-
 			// Step 5: Cache result under user tenant/org (regardless of where form was found)
 			if (formFromDb) {
 				await this.set(tenantCode, orgCode, type, subtype, formFromDb)
@@ -813,9 +810,7 @@ const forms = {
 		const compositeId = `${type}:${subtype}`
 		const useInternal = nsUseInternal('forms')
 		const cacheKey = await buildKey({ tenantCode, orgCode: orgCode, ns: 'forms', id: compositeId })
-		console.log(`[FormCache] Deleting key: ${cacheKey}`)
 		const result = await del(cacheKey, { useInternal })
-		console.log(`[FormCache] Deleted key: ${cacheKey}`)
 		return result
 	},
 

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -833,9 +833,7 @@ const forms = {
 	 */
 	async deleteAcrossAllOrgs(tenantCode, type, subtype) {
 		const pattern = `tenant:${tenantCode}:org:*:forms:${type}:${subtype}`
-		console.log(`[FormCache] deleteAcrossAllOrgs - scanning and deleting pattern: ${pattern}`)
 		const result = await scanAndDelete(pattern)
-		console.log(`[FormCache] deleteAcrossAllOrgs - done for pattern: ${pattern}`)
 		return result
 	},
 }

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -810,8 +810,7 @@ const forms = {
 		const compositeId = `${type}:${subtype}`
 		const useInternal = nsUseInternal('forms')
 		const cacheKey = await buildKey({ tenantCode, orgCode: orgCode, ns: 'forms', id: compositeId })
-		const result = await del(cacheKey, { useInternal })
-		return result
+		return del(cacheKey, { useInternal })
 	},
 
 	/**

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -723,6 +723,7 @@ const forms = {
 	 */
 	async get(tenantCode, orgCode, type, subtype) {
 		try {
+			console.log('Entering......')
 			const compositeId = `${type}:${subtype}`
 			const useInternal = nsUseInternal('forms')
 
@@ -768,6 +769,8 @@ const forms = {
 				return null
 			}
 
+			console.log(formFromDb, '<<--formFromDb 771')
+
 			// Step 5: Cache result under user tenant/org (regardless of where form was found)
 			if (formFromDb) {
 				await this.set(tenantCode, orgCode, type, subtype, formFromDb)
@@ -810,7 +813,10 @@ const forms = {
 		const compositeId = `${type}:${subtype}`
 		const useInternal = nsUseInternal('forms')
 		const cacheKey = await buildKey({ tenantCode, orgCode: orgCode, ns: 'forms', id: compositeId })
-		return del(cacheKey, { useInternal })
+		console.log(`[FormCache] Deleting key: ${cacheKey}`)
+		const result = await del(cacheKey, { useInternal })
+		console.log(`[FormCache] Deleted key: ${cacheKey}`)
+		return result
 	},
 
 	/**
@@ -818,6 +824,19 @@ const forms = {
 	 */
 	async evictAll(tenantCode, orgCode) {
 		return await evictNamespace({ tenantCode, orgCode: orgCode, ns: 'forms' })
+	},
+
+	/**
+	 * Invalidate a specific form across ALL orgs in a tenant.
+	 * Used when the default org updates a form — other orgs may have cached
+	 * the default org's form data under their own org key via fallback logic.
+	 */
+	async deleteAcrossAllOrgs(tenantCode, type, subtype) {
+		const pattern = `tenant:${tenantCode}:org:*:forms:${type}:${subtype}`
+		console.log(`[FormCache] deleteAcrossAllOrgs - scanning and deleting pattern: ${pattern}`)
+		const result = await scanAndDelete(pattern)
+		console.log(`[FormCache] deleteAcrossAllOrgs - done for pattern: ${pattern}`)
+		return result
 	},
 }
 

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -105,7 +105,7 @@ module.exports = class FormsHelper {
 			}
 			//await KafkaProducer.clearInternalCache('formVersion')
 
-			// Cache invalidation after successful update
+			// Cache invalidation after successful update just delete, don't re-set
 			try {
 				if (originalForm && originalForm.type && originalForm.sub_type) {
 					const isDefaultOrg = originalForm.organization_code === process.env.DEFAULT_ORGANISATION_CODE
@@ -158,7 +158,6 @@ module.exports = class FormsHelper {
 		try {
 			// Try to get from cache first if searching by type and subtype (not by ID)
 			if (!id && bodyData?.type && bodyData?.sub_type) {
-				console.log('line 176 ... quering the cacheHelper..')
 				const cachedData = await cacheHelper.forms.get(tenantCode, orgCode, bodyData.type, bodyData.sub_type)
 				if (cachedData) {
 					return responses.successResponse({

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -112,7 +112,7 @@ module.exports = class FormsHelper {
 					if (isDefaultOrg) {
 						// Default org update: other orgs may have cached this form via fallback
 						// under their own org key — sweep all of them
-						await cacheHelper.forms.deleteAcrossAllOrgs(
+						await cacheHelper.forms.deleteFormsAcrossAllOrgs(
 							tenantCode,
 							originalForm.type,
 							originalForm.sub_type

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -202,9 +202,8 @@ module.exports = class FormsHelper {
 				})
 			}
 
-			// Business logic: Prefer current tenant over default tenant
-			const form = forms.find((f) => f.tenant_code === tenantCode) || forms[0]
-
+			// Business logic: Prefer current org over default org
+			const form = forms.find((f) => f.organization_code === orgCode) || forms[0]
 			// Cache the result if it was searched by type and subtype
 			if (!id && bodyData?.type && bodyData?.sub_type) {
 				await cacheHelper.forms.set(tenantCode, orgCode, bodyData.type, bodyData.sub_type, form)
@@ -237,53 +236,6 @@ module.exports = class FormsHelper {
 
 			// Fetch all forms from database (no "all forms" cache to avoid duplication)
 			const formsVersionData = (await form.getAllFormsVersion(tenantCode)) || {}
-
-			// Cache each individual form for future individual reads
-			try {
-				if (Array.isArray(formsVersionData) && formsVersionData.length > 0) {
-					console.log(`Populating individual form caches for ${formsVersionData.length} forms...`)
-					const cachePromises = []
-
-					// For each form in the version data, fetch complete form and cache it
-					for (const formVersion of formsVersionData) {
-						if (formVersion.type) {
-							// Create a promise to fetch and cache the complete form
-							const cachePromise = (async () => {
-								try {
-									// Fetch complete form data by type (this should include sub_type)
-									const completeFormData = await formQueries.findFormsByFilter(
-										{ type: formVersion.type },
-										tenantCode
-									)
-
-									if (completeFormData && completeFormData.length > 0) {
-										const formData = completeFormData[0]
-										if (formData.sub_type) {
-											await cacheHelper.forms.set(
-												tenantCode,
-												formData.organization_code || defaults.orgCode,
-												formData.type,
-												formData.sub_type,
-												formData
-											)
-										}
-									}
-								} catch (error) {
-									console.warn(`Failed to cache individual form for type ${formVersion.type}:`, error)
-								}
-							})()
-
-							cachePromises.push(cachePromise)
-						}
-					}
-
-					// Execute all individual cache operations in parallel
-					await Promise.all(cachePromises)
-					console.log(`Individual forms cache population completed for tenant: ${tenantCode}`)
-				}
-			} catch (individualCacheError) {
-				console.warn('Failed to populate individual forms cache:', individualCacheError)
-			}
 
 			return responses.successResponse({
 				statusCode: httpStatusCode.ok,

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -105,40 +105,24 @@ module.exports = class FormsHelper {
 			}
 			//await KafkaProducer.clearInternalCache('formVersion')
 
-			// Cache invalidation after successful update: just delete, don't re-set
+			// Cache invalidation after successful update
 			try {
 				if (originalForm && originalForm.type && originalForm.sub_type) {
 					const isDefaultOrg = originalForm.organization_code === process.env.DEFAULT_ORGANISATION_CODE
 					if (isDefaultOrg) {
 						// Default org update: other orgs may have cached this form via fallback
 						// under their own org key — sweep all of them
-						console.log(
-							`[FormCache] Default org update detected (org: ${originalForm.organization_code}). ` +
-								`Sweeping all org caches for tenant:${tenantCode}:org:*:forms:${originalForm.type}:${originalForm.sub_type}`
-						)
 						await cacheHelper.forms.deleteAcrossAllOrgs(
 							tenantCode,
 							originalForm.type,
 							originalForm.sub_type
 						)
-						console.log(
-							`[FormCache] Cross-org invalidation complete for ${originalForm.type}:${originalForm.sub_type}`
-						)
 					} else {
-						console.log(
-							`[FormCache] Non-default org update (org: ${originalForm.organization_code || orgCode}). ` +
-								`Invalidating tenant:${tenantCode}:org:${
-									originalForm.organization_code || orgCode
-								}:forms:${originalForm.type}:${originalForm.sub_type}`
-						)
 						await cacheHelper.forms.delete(
 							tenantCode,
 							originalForm.organization_code || orgCode,
 							originalForm.type,
 							originalForm.sub_type
-						)
-						console.log(
-							`[FormCache] Single-org invalidation complete for ${originalForm.type}:${originalForm.sub_type}`
 						)
 					}
 				}

--- a/src/services/form.js
+++ b/src/services/form.js
@@ -31,6 +31,15 @@ module.exports = class FormsHelper {
 
 			//await KafkaProducer.clearInternalCache('formVersion')
 
+			// Invalidate cache so stale fallback (default org) is not served
+			try {
+				if (bodyData.type && bodyData.sub_type) {
+					await cacheHelper.forms.delete(tenantCode, orgCode, bodyData.type, bodyData.sub_type)
+				}
+			} catch (cacheError) {
+				console.error('Failed to invalidate form cache:', cacheError)
+			}
+
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
 				message: 'FORM_CREATED_SUCCESSFULLY',
@@ -99,13 +108,39 @@ module.exports = class FormsHelper {
 			// Cache invalidation after successful update: just delete, don't re-set
 			try {
 				if (originalForm && originalForm.type && originalForm.sub_type) {
-					// Delete the form cache using original form's type/subtype information
-					await cacheHelper.forms.delete(
-						tenantCode,
-						originalForm.organization_code || orgCode,
-						originalForm.type,
-						originalForm.sub_type
-					)
+					const isDefaultOrg = originalForm.organization_code === process.env.DEFAULT_ORGANISATION_CODE
+					if (isDefaultOrg) {
+						// Default org update: other orgs may have cached this form via fallback
+						// under their own org key — sweep all of them
+						console.log(
+							`[FormCache] Default org update detected (org: ${originalForm.organization_code}). ` +
+								`Sweeping all org caches for tenant:${tenantCode}:org:*:forms:${originalForm.type}:${originalForm.sub_type}`
+						)
+						await cacheHelper.forms.deleteAcrossAllOrgs(
+							tenantCode,
+							originalForm.type,
+							originalForm.sub_type
+						)
+						console.log(
+							`[FormCache] Cross-org invalidation complete for ${originalForm.type}:${originalForm.sub_type}`
+						)
+					} else {
+						console.log(
+							`[FormCache] Non-default org update (org: ${originalForm.organization_code || orgCode}). ` +
+								`Invalidating tenant:${tenantCode}:org:${
+									originalForm.organization_code || orgCode
+								}:forms:${originalForm.type}:${originalForm.sub_type}`
+						)
+						await cacheHelper.forms.delete(
+							tenantCode,
+							originalForm.organization_code || orgCode,
+							originalForm.type,
+							originalForm.sub_type
+						)
+						console.log(
+							`[FormCache] Single-org invalidation complete for ${originalForm.type}:${originalForm.sub_type}`
+						)
+					}
 				}
 			} catch (error) {
 				console.warn('Failed to invalidate form cache:', error)
@@ -139,6 +174,7 @@ module.exports = class FormsHelper {
 		try {
 			// Try to get from cache first if searching by type and subtype (not by ID)
 			if (!id && bodyData?.type && bodyData?.sub_type) {
+				console.log('line 176 ... quering the cacheHelper..')
 				const cachedData = await cacheHelper.forms.get(tenantCode, orgCode, bodyData.type, bodyData.sub_type)
 				if (cachedData) {
 					return responses.successResponse({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Added cache helper method deleteFormsAcrossAllOrgs(tenantCode, type, subtype) to invalidate form cache entries across all organizations within a tenant
- Form creation now attempts to invalidate the created form's cache entry after successful creation (cache-delete failures are caught and logged)
- Form update now invalidates caches more precisely:
  - If the updated form belongs to the default organization (process.env.DEFAULT_ORGANISATION_CODE), invalidates cached entries across all organizations
  - Otherwise, invalidates the cache only for the specific organization
- Forms read logic now prefers matching organization_code over tenant_code when selecting fallback forms
- Removed logic that populated individual form cache entries inside readAllFormsVersion (method now returns formsVersionData only)

## Lines Changed by Contributor

| Author | File | Added | Removed |
|--------|------:|------:|--------:|
| borkarsaish65 | src/generics/cacheHelper.js | 1779 | 0 |
| borkarsaish65 | src/services/form.js | 249 | 0 |
| **Total** | | **2028** | **0** |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->