### PR TITLE
Fix/notification template2

### DIFF
--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -1481,7 +1481,23 @@ const notificationTemplates = {
 		const compositeId = `templateCode:${templateCode}`
 		const useInternal = nsUseInternal('notificationTemplates')
 		const cacheKey = await buildKey({ tenantCode, orgCode: orgCode, ns: 'notificationTemplates', id: compositeId })
-		return del(cacheKey, { useInternal })
+		console.log(`[NotifCache] Deleting key: ${cacheKey}`)
+		const result = await del(cacheKey, { useInternal })
+		console.log(`[NotifCache] Deleted key: ${cacheKey}`)
+		return result
+	},
+
+	/**
+	 * Invalidate a specific notification template across ALL orgs in a tenant.
+	 * Used when the default org updates a template — other orgs may have cached
+	 * the default org's template under their own org key via fallback logic.
+	 */
+	async deleteAcrossAllOrgs(tenantCode, templateCode) {
+		const pattern = `tenant:${tenantCode}:org:*:notificationTemplates:templateCode:${templateCode}`
+		console.log(`[NotifCache] deleteAcrossAllOrgs - scanning and deleting pattern: ${pattern}`)
+		const result = await scanAndDelete(pattern)
+		console.log(`[NotifCache] deleteAcrossAllOrgs - done for pattern: ${pattern}`)
+		return result
 	},
 }
 

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -1489,7 +1489,7 @@ const notificationTemplates = {
 	 * Used when the default org updates a template — other orgs may have cached
 	 * the default org's template under their own org key via fallback logic.
 	 */
-	async deleteAcrossAllOrgs(tenantCode, templateCode) {
+	async deleteNotificationsAcrossAllOrgs(tenantCode, templateCode) {
 		const pattern = `tenant:${tenantCode}:org:*:notificationTemplates:templateCode:${templateCode}`
 		const result = await scanAndDelete(pattern)
 		return result

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -1481,10 +1481,7 @@ const notificationTemplates = {
 		const compositeId = `templateCode:${templateCode}`
 		const useInternal = nsUseInternal('notificationTemplates')
 		const cacheKey = await buildKey({ tenantCode, orgCode: orgCode, ns: 'notificationTemplates', id: compositeId })
-		console.log(`[NotifCache] Deleting key: ${cacheKey}`)
-		const result = await del(cacheKey, { useInternal })
-		console.log(`[NotifCache] Deleted key: ${cacheKey}`)
-		return result
+		return del(cacheKey, { useInternal })
 	},
 
 	/**
@@ -1494,9 +1491,7 @@ const notificationTemplates = {
 	 */
 	async deleteAcrossAllOrgs(tenantCode, templateCode) {
 		const pattern = `tenant:${tenantCode}:org:*:notificationTemplates:templateCode:${templateCode}`
-		console.log(`[NotifCache] deleteAcrossAllOrgs - scanning and deleting pattern: ${pattern}`)
 		const result = await scanAndDelete(pattern)
-		console.log(`[NotifCache] deleteAcrossAllOrgs - done for pattern: ${pattern}`)
 		return result
 	},
 }

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -107,23 +107,13 @@ module.exports = class NotificationTemplateHelper {
 					if (isDefaultOrg) {
 						// Default org update: other orgs may have cached this template via fallback
 						// under their own org key — sweep all of them
-						console.log(
-							`[NotifCache] Default org update detected (org: ${tokenInformation.organization_code}). ` +
-								`Sweeping all org caches for tenant:${tenantCode}:org:*:notificationTemplates:templateCode:${templateCode}`
-						)
 						await cacheHelper.notificationTemplates.deleteAcrossAllOrgs(tenantCode, templateCode)
-						console.log(`[NotifCache] Cross-org invalidation complete for templateCode:${templateCode}`)
 					} else {
-						console.log(
-							`[NotifCache] Non-default org update (org: ${tokenInformation.organization_code}). ` +
-								`Invalidating tenant:${tenantCode}:org:${tokenInformation.organization_code}:notificationTemplates:templateCode:${templateCode}`
-						)
 						await cacheHelper.notificationTemplates.delete(
 							tenantCode,
 							tokenInformation.organization_code,
 							templateCode
 						)
-						console.log(`[NotifCache] Single-org invalidation complete for templateCode:${templateCode}`)
 					}
 				}
 				// If the template code itself was changed, also clear the old code

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -39,6 +39,17 @@ module.exports = class NotificationTemplateHelper {
 
 			const createdNotification = await notificationTemplateQueries.create(bodyData, tenantCode)
 
+			// Invalidate cache so stale fallback (default org) is not served
+			try {
+				await cacheHelper.notificationTemplates.delete(
+					tenantCode,
+					tokenInformation.organization_code,
+					bodyData.code
+				)
+			} catch (cacheError) {
+				console.error('❌ Failed to invalidate notification template cache:', cacheError)
+			}
+
 			return responses.successResponse({
 				statusCode: httpStatusCode.created,
 				message: 'NOTIFICATION_TEMPLATE_CREATED_SUCCESSFULLY',
@@ -75,6 +86,10 @@ module.exports = class NotificationTemplateHelper {
 			bodyData['organization_code'] = tokenInformation.organization_code
 			bodyData['updated_by'] = tokenInformation.id
 
+			// Fetch existing template BEFORE update to capture the old code for cache invalidation
+			const existingTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
+			const existingTemplate = existingTemplates?.[0]
+
 			const result = await notificationTemplateQueries.updateTemplate(filter, bodyData, tenantCode)
 			if (result == 0) {
 				return responses.failureResponse({
@@ -85,8 +100,6 @@ module.exports = class NotificationTemplateHelper {
 			}
 
 			// Delete old cache
-			const existingTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
-			const existingTemplate = existingTemplates?.[0]
 			const templateCode = bodyData.code || existingTemplate?.code || filter.code
 			const isDefaultOrg = tokenInformation.organization_code === process.env.DEFAULT_ORGANISATION_CODE
 			try {
@@ -252,21 +265,18 @@ module.exports = class NotificationTemplateHelper {
 			// Cache each individual template for future single reads
 			if (notificationTemplates && notificationTemplates.length > 0) {
 				try {
-					console.log(`Caching ${notificationTemplates.length} notification templates individually...`)
-					const cachePromises = []
-
+					const templatesByCode = {}
 					for (const template of notificationTemplates) {
-						if (template.code) {
-							const cachePromise = cacheHelper.notificationTemplates.set(
-								tenantCode,
-								organizationCode,
-								template.code,
-								template
-							)
-							cachePromises.push(cachePromise)
+						if (!template.code) continue
+						// Only set if not yet seen, or if this template belongs to user's own org (higher priority)
+						if (!templatesByCode[template.code] || template.organization_code === organizationCode) {
+							templatesByCode[template.code] = template
 						}
 					}
 
+					const cachePromises = Object.entries(templatesByCode).map(([code, template]) =>
+						cacheHelper.notificationTemplates.set(tenantCode, organizationCode, code, template)
+					)
 					await Promise.all(cachePromises)
 				} catch (cacheError) {
 					console.warn('Failed to cache individual notification templates:', cacheError)

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -88,20 +88,42 @@ module.exports = class NotificationTemplateHelper {
 			const existingTemplates = await notificationTemplateQueries.findTemplatesByFilter(filter)
 			const existingTemplate = existingTemplates?.[0]
 			const templateCode = bodyData.code || existingTemplate?.code || filter.code
+			const isDefaultOrg = tokenInformation.organization_code === process.env.DEFAULT_ORGANISATION_CODE
 			try {
 				if (templateCode) {
-					await cacheHelper.notificationTemplates.delete(
-						tenantCode,
-						tokenInformation.organization_code,
-						templateCode
-					)
+					if (isDefaultOrg) {
+						// Default org update: other orgs may have cached this template via fallback
+						// under their own org key — sweep all of them
+						console.log(
+							`[NotifCache] Default org update detected (org: ${tokenInformation.organization_code}). ` +
+								`Sweeping all org caches for tenant:${tenantCode}:org:*:notificationTemplates:templateCode:${templateCode}`
+						)
+						await cacheHelper.notificationTemplates.deleteAcrossAllOrgs(tenantCode, templateCode)
+						console.log(`[NotifCache] Cross-org invalidation complete for templateCode:${templateCode}`)
+					} else {
+						console.log(
+							`[NotifCache] Non-default org update (org: ${tokenInformation.organization_code}). ` +
+								`Invalidating tenant:${tenantCode}:org:${tokenInformation.organization_code}:notificationTemplates:templateCode:${templateCode}`
+						)
+						await cacheHelper.notificationTemplates.delete(
+							tenantCode,
+							tokenInformation.organization_code,
+							templateCode
+						)
+						console.log(`[NotifCache] Single-org invalidation complete for templateCode:${templateCode}`)
+					}
 				}
+				// If the template code itself was changed, also clear the old code
 				if (existingTemplate?.code && existingTemplate.code !== templateCode) {
-					await cacheHelper.notificationTemplates.delete(
-						tenantCode,
-						tokenInformation.organization_code,
-						existingTemplate.code
-					)
+					if (isDefaultOrg) {
+						await cacheHelper.notificationTemplates.deleteAcrossAllOrgs(tenantCode, existingTemplate.code)
+					} else {
+						await cacheHelper.notificationTemplates.delete(
+							tenantCode,
+							tokenInformation.organization_code,
+							existingTemplate.code
+						)
+					}
 				}
 			} catch (cacheError) {
 				console.error(`❌ Failed to update notification template cache:`, cacheError)

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -106,7 +106,7 @@ module.exports = class NotificationTemplateHelper {
 			try {
 				if (oldCode) {
 					if (isDefaultOrg) {
-						await cacheHelper.notificationTemplates.deleteAcrossAllOrgs(tenantCode, oldCode)
+						await cacheHelper.notificationTemplates.deleteNotificationsAcrossAllOrgs(tenantCode, oldCode)
 					} else {
 						await cacheHelper.notificationTemplates.delete(
 							tenantCode,
@@ -117,7 +117,7 @@ module.exports = class NotificationTemplateHelper {
 				}
 				if (newCode && newCode !== oldCode) {
 					if (isDefaultOrg) {
-						await cacheHelper.notificationTemplates.deleteAcrossAllOrgs(tenantCode, newCode)
+						await cacheHelper.notificationTemplates.deleteNotificationsAcrossAllOrgs(tenantCode, newCode)
 					} else {
 						await cacheHelper.notificationTemplates.delete(
 							tenantCode,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Changes
- **Cache Helper Enhancement**: Added `deleteAcrossAllOrgs(tenantCode, templateCode)` method to support cache invalidation across all organization scopes for a given tenant and template code.
- **Notification Template Creation**: Added cache invalidation for the creating organization's cached template entry upon successful creation.
- **Notification Template Updates**: Enhanced cache management to differentiate between default and non-default organization updates:
  - Default org updates now invalidate cache across all organizations
  - Non-default org updates invalidate cache only for the specific organization
  - Both new and old template codes are properly invalidated when template code changes
- **Bulk Template Caching Optimization**: Improved `readAllNotificationTemplates` to deduplicate templates by code, prioritizing the user's own organization template, and removed redundant console logging.

### Lines Changed by Author

| Author | Added | Removed |
|--------|-------|---------|
| borkarsaish65 | 56 | 23 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->