### PR TITLE
entities and entity type fix for cache invalidation

### DIFF
--- a/src/database/queries/userExtension.js
+++ b/src/database/queries/userExtension.js
@@ -712,11 +712,12 @@ module.exports = class MenteeExtensionQueries {
 
 	static async getAllUsersByOrgId(orgCodes, tenantCode) {
 		try {
-			const viewName = utils.getTenantViewName(tenantCode, MenteeExtension.tableName)
-
 			if (!Array.isArray(orgCodes) || orgCodes.length === 0) {
 				return []
 			}
+
+			const viewName = utils.getTenantViewName(tenantCode, MenteeExtension.tableName)
+
 			const query = `
 			SELECT user_id
 			FROM ${viewName}

--- a/src/database/queries/userExtension.js
+++ b/src/database/queries/userExtension.js
@@ -712,11 +712,17 @@ module.exports = class MenteeExtensionQueries {
 
 	static async getAllUsersByOrgId(orgCodes, tenantCode) {
 		try {
+			const viewName = utils.getTenantViewName(tenantCode, MenteeExtension.tableName)
+
+			// null orgCodes = all orgs (used for default-org cross-org cache invalidation)
+			if (orgCodes === null) {
+				const query = `SELECT user_id FROM ${viewName} WHERE tenant_code = :tenantCode`
+				return await Sequelize.query(query, { type: QueryTypes.SELECT, replacements: { tenantCode } })
+			}
+
 			if (!Array.isArray(orgCodes) || orgCodes.length === 0) {
 				return []
 			}
-			const viewName = utils.getTenantViewName(tenantCode, MenteeExtension.tableName)
-
 			const query = `
 			SELECT user_id
 			FROM ${viewName}

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -373,9 +373,7 @@ const sessions = {
 		const pattern = orgCode
 			? `tenant:${tenantCode}:org:${orgCode}:sessions:*`
 			: `tenant:${tenantCode}:org:*:sessions:*`
-		console.log(`[SessionCache] deleteAll - scanning and deleting pattern: ${pattern}`)
 		const result = await scanAndDelete(pattern)
-		console.log(`[SessionCache] deleteAll - deleted ${result} key(s)`)
 		return result
 	},
 

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -948,9 +948,7 @@ const mentor = {
 
 	async deleteAll(tenantCode) {
 		const pattern = `tenant:${tenantCode}:mentor:*`
-		console.log(`[MentorCache] deleteAll - scanning and deleting pattern: ${pattern}`)
 		const result = await scanAndDelete(pattern)
-		console.log(`[MentorCache] deleteAll - deleted ${result} key(s)`)
 		return result
 	},
 
@@ -1195,9 +1193,7 @@ const mentee = {
 
 	async deleteAll(tenantCode) {
 		const pattern = `tenant:${tenantCode}:mentee:*`
-		console.log(`[MenteeCache] deleteAll - scanning and deleting pattern: ${pattern}`)
 		const result = await scanAndDelete(pattern)
-		console.log(`[MenteeCache] deleteAll - deleted ${result} key(s)`)
 		return result
 	},
 

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -369,10 +369,8 @@ const sessions = {
 		return del(cacheKey, { useInternal })
 	},
 
-	async deleteAll(tenantCode, orgCode = null) {
-		const pattern = orgCode
-			? `tenant:${tenantCode}:org:${orgCode}:sessions:*`
-			: `tenant:${tenantCode}:org:*:sessions:*`
+	async deleteAll(tenantCode) {
+		const pattern = `tenant:${tenantCode}:sessions:*`
 		const result = await scanAndDelete(pattern)
 		return result
 	},

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -369,6 +369,16 @@ const sessions = {
 		return del(cacheKey, { useInternal })
 	},
 
+	async deleteAll(tenantCode, orgCode = null) {
+		const pattern = orgCode
+			? `tenant:${tenantCode}:org:${orgCode}:sessions:*`
+			: `tenant:${tenantCode}:org:*:sessions:*`
+		console.log(`[SessionCache] deleteAll - scanning and deleting pattern: ${pattern}`)
+		const result = await scanAndDelete(pattern)
+		console.log(`[SessionCache] deleteAll - deleted ${result} key(s)`)
+		return result
+	},
+
 	async reset(tenantCode, sessionId, sessionData, customTtl = null) {
 		return this.set(tenantCode, sessionId, sessionData, customTtl)
 	},

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -611,6 +611,17 @@ const entityTypes = {
 		return del(cacheKey, { useInternal })
 	},
 
+	/**
+	 * Invalidate a specific entity type across ALL orgs in a tenant.
+	 * Used when the default org updates an entity type — other orgs may have cached
+	 * the default org's data under their own org key via fallback logic.
+	 */
+	async deleteAcrossAllOrgs(tenantCode, modelName, entityValue) {
+		const pattern = `tenant:${tenantCode}:org:*:entityTypes:model:${modelName}:${entityValue}`
+		const result = await scanAndDelete(pattern)
+		return result
+	},
+
 	// Clear all entityTypes cache for a tenant/org (useful after cache key format changes)
 	async clearAll(tenantCode, orgCode) {
 		return await evictNamespace({ tenantCode, orgCode: orgCode, ns: 'entityTypes' })

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -1587,6 +1587,14 @@ const displayProperties = {
 		await del(orgKey, { useInternal })
 		await del(tenantKey, { useInternal })
 	},
+	async deleteAll(tenantCode) {
+		// Delete all org-level displayProperties
+		const pattern = `tenant:${tenantCode}:org:*:displayProperties`
+		await scanAndDelete(pattern)
+		// Optional: delete tenant-level fallback
+		const tenantPattern = `tenant:${tenantCode}:org::displayProperties`
+		await scanAndDelete(tenantPattern)
+	},
 }
 
 /**

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -616,7 +616,7 @@ const entityTypes = {
 	 * Used when the default org updates an entity type — other orgs may have cached
 	 * the default org's data under their own org key via fallback logic.
 	 */
-	async deleteAcrossAllOrgs(tenantCode, modelName, entityValue) {
+	async deleteEntityTypesAcrossAllOrgs(tenantCode, modelName, entityValue) {
 		const pattern = `tenant:${tenantCode}:org:*:entityTypes:model:${modelName}:${entityValue}`
 		const result = await scanAndDelete(pattern)
 		return result

--- a/src/generics/cacheHelper.js
+++ b/src/generics/cacheHelper.js
@@ -1591,9 +1591,6 @@ const displayProperties = {
 		// Delete all org-level displayProperties
 		const pattern = `tenant:${tenantCode}:org:*:displayProperties`
 		await scanAndDelete(pattern)
-		// Optional: delete tenant-level fallback
-		const tenantPattern = `tenant:${tenantCode}:org::displayProperties`
-		await scanAndDelete(tenantPattern)
 	},
 }
 

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -105,9 +105,9 @@ module.exports = class EntityHelper {
 			}
 
 			// Cache invalidation after successful update: just delete using original entity data
+			const isDefaultOrg = orgCode === process.env.DEFAULT_ORGANISATION_CODE
 			try {
 				if (originalEntity && originalEntity.model_names && originalEntity.value) {
-					const isDefaultOrg = orgCode === process.env.DEFAULT_ORGANISATION_CODE
 					for (const modelName of originalEntity.model_names) {
 						if (isDefaultOrg) {
 							// Default org update: other orgs may have cached this entity type via fallback
@@ -132,7 +132,8 @@ module.exports = class EntityHelper {
 				orgCode,
 				tenantCode,
 				updatedEntity.model_names ? updatedEntity.model_names[0] : null,
-				updatedEntity.value
+				updatedEntity.value,
+				isDefaultOrg
 			)
 
 			return responses.successResponse({
@@ -371,7 +372,8 @@ module.exports = class EntityHelper {
 				organizationCode,
 				tenantCode,
 				entityToDelete.model_names ? entityToDelete.model_names[0] : null,
-				entityToDelete.value
+				entityToDelete.value,
+				isDefaultOrg
 			)
 
 			return responses.successResponse({
@@ -546,7 +548,8 @@ module.exports = class EntityHelper {
 		organizationCode,
 		tenantCode,
 		modelName = null,
-		entityValue = null
+		entityValue = null,
+		allOrgs = false
 	) {
 		try {
 			const logContext = modelName ? `${modelName}:${entityValue}` : 'global'
@@ -592,7 +595,10 @@ module.exports = class EntityHelper {
 				if (modelName === menteeModelName) {
 					// Clear all mentee caches for this organization
 					try {
-						const users = await menteeExtensionQueries.getAllUsersByOrgId([organizationCode], tenantCode)
+						const users = await menteeExtensionQueries.getAllUsersByOrgId(
+							allOrgs ? null : [organizationCode],
+							tenantCode
+						)
 						const menteeUserIds = users.map((user) => user.user_id)
 
 						// Clear mentee caches for all users in organization
@@ -611,7 +617,10 @@ module.exports = class EntityHelper {
 					// Clear all mentor caches for this organization
 					try {
 						// Get all users who might be mentors in this organization
-						const users = await menteeExtensionQueries.getAllUsersByOrgId([organizationCode], tenantCode)
+						const users = await menteeExtensionQueries.getAllUsersByOrgId(
+							allOrgs ? null : [organizationCode],
+							tenantCode
+						)
 						const mentorUserIds = users.map((user) => user.user_id)
 
 						// Clear mentor caches for all users in organization (users can be both mentee and mentor)

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -107,9 +107,19 @@ module.exports = class EntityHelper {
 			// Cache invalidation after successful update: just delete using original entity data
 			try {
 				if (originalEntity && originalEntity.model_names && originalEntity.value) {
-					// Delete cache entries using original entity's model_names and value
+					const isDefaultOrg = orgCode === process.env.DEFAULT_ORGANISATION_CODE
 					for (const modelName of originalEntity.model_names) {
-						await cacheHelper.entityTypes.delete(tenantCode, orgCode, modelName, originalEntity.value)
+						if (isDefaultOrg) {
+							// Default org update: other orgs may have cached this entity type via fallback
+							// under their own org key — sweep all of them
+							await cacheHelper.entityTypes.deleteAcrossAllOrgs(
+								tenantCode,
+								modelName,
+								originalEntity.value
+							)
+						} else {
+							await cacheHelper.entityTypes.delete(tenantCode, orgCode, modelName, originalEntity.value)
+						}
 					}
 				}
 			} catch (cacheError) {

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -568,11 +568,8 @@ module.exports = class EntityHelper {
 				}
 
 				if (modelName === sessionModelName) {
-					if (allOrgs) {
-						clearPromises.push(cacheHelper.sessions.deleteAll(tenantCode).catch(() => {}))
-					} else {
-						clearPromises.push(cacheHelper.sessions.deleteAll(tenantCode, organizationCode).catch(() => {}))
-					}
+					// Session keys have no org scope, so always sweep all sessions for the tenant
+					clearPromises.push(cacheHelper.sessions.deleteAll(tenantCode).catch(() => {}))
 				}
 			}
 

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -296,6 +296,7 @@ module.exports = class EntityHelper {
 			}
 
 			// SECOND: Delete from database
+			const isDefaultOrg = organizationCode === process.env.DEFAULT_ORGANISATION_CODE
 			const deleteCount = await entityTypeQueries.deleteOneEntityType(id, organizationCode, tenantCode)
 			if (deleteCount === 0) {
 				return responses.failureResponse({
@@ -311,7 +312,8 @@ module.exports = class EntityHelper {
 					organizationCode,
 					tenantCode,
 					modelName,
-					entityToDelete.value
+					entityToDelete.value,
+					isDefaultOrg
 				)
 			}
 

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -300,11 +300,15 @@ module.exports = class EntityHelper {
 			}
 
 			// Clear cache for affected models before deletion
-			await this._clearUserCachesForEntityTypeChange(organizationCode, tenantCode, {
-				id: entityToDelete.id,
-				value: entityToDelete.value,
-				modelNames: entityToDelete.model_names,
-			})
+			const isDefaultOrg = organizationCode === process.env.DEFAULT_ORGANISATION_CODE
+
+			await this._clearUserCachesForEntityTypeChange(
+				organizationCode,
+				tenantCode,
+				entityToDelete.model_names ? entityToDelete.model_names[0] : null,
+				entityToDelete.value,
+				isDefaultOrg
+			)
 
 			// SECOND: Delete from database
 			const deleteCount = await entityTypeQueries.deleteOneEntityType(id, organizationCode, tenantCode)
@@ -317,7 +321,6 @@ module.exports = class EntityHelper {
 			}
 
 			// THIRD: Remove individual entity type from cache
-			const isDefaultOrg = organizationCode === process.env.DEFAULT_ORGANISATION_CODE
 			try {
 				// For each model this entity belonged to
 				if (entityToDelete.model_names && Array.isArray(entityToDelete.model_names)) {

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -316,17 +316,26 @@ module.exports = class EntityHelper {
 			}
 
 			// THIRD: Remove individual entity type from cache
+			const isDefaultOrg = organizationCode === process.env.DEFAULT_ORGANISATION_CODE
 			try {
 				// For each model this entity belonged to
 				if (entityToDelete.model_names && Array.isArray(entityToDelete.model_names)) {
 					for (const modelName of entityToDelete.model_names) {
 						// Remove the specific entity type cache
-						await cacheHelper.entityTypes.delete(
-							tenantCode,
-							organizationCode,
-							modelName,
-							entityToDelete.value
-						)
+						if (isDefaultOrg) {
+							await cacheHelper.entityTypes.deleteEntityTypesAcrossAllOrgs(
+								tenantCode,
+								modelName,
+								entityToDelete.value
+							)
+						} else {
+							await cacheHelper.entityTypes.delete(
+								tenantCode,
+								organizationCode,
+								modelName,
+								entityToDelete.value
+							)
+						}
 					}
 				}
 			} catch (cacheError) {
@@ -336,12 +345,20 @@ module.exports = class EntityHelper {
 				if (entityToDelete.model_names && Array.isArray(entityToDelete.model_names)) {
 					for (const modelName of entityToDelete.model_names) {
 						try {
-							await cacheHelper.entityTypes.delete(
-								tenantCode,
-								organizationCode,
-								modelName,
-								entityToDelete.value
-							)
+							if (isDefaultOrg) {
+								await cacheHelper.entityTypes.deleteEntityTypesAcrossAllOrgs(
+									tenantCode,
+									modelName,
+									entityToDelete.value
+								)
+							} else {
+								await cacheHelper.entityTypes.delete(
+									tenantCode,
+									organizationCode,
+									modelName,
+									entityToDelete.value
+								)
+							}
 						} catch (retryError) {
 							// Failed to retry clear cache - continue operation
 						}

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -106,30 +106,16 @@ module.exports = class EntityHelper {
 
 			// Cache invalidation after successful update: just delete using original entity data
 			const isDefaultOrg = orgCode === process.env.DEFAULT_ORGANISATION_CODE
-			try {
-				if (originalEntity && originalEntity.model_names && originalEntity.value) {
-					for (const modelName of originalEntity.model_names) {
-						if (isDefaultOrg) {
-							// Default org update: other orgs may have cached this entity type via fallback
-							// under their own org key — sweep all of them
-							await cacheHelper.entityTypes.deleteEntityTypesAcrossAllOrgs(
-								tenantCode,
-								modelName,
-								originalEntity.value
-							)
-						} else {
-							await cacheHelper.entityTypes.delete(tenantCode, orgCode, modelName, originalEntity.value)
-						}
-					}
+			if (originalEntity && originalEntity.model_names) {
+				for (const modelName of originalEntity.model_names) {
+					await this._clearUserCachesForEntityTypeChange(
+						orgCode,
+						tenantCode,
+						modelName,
+						originalEntity.value,
+						isDefaultOrg
+					)
 				}
-			} catch (cacheError) {
-				// Failed to invalidate entity type cache - continue operation
-			}
-
-			// Clear user caches since entity types affect user profiles
-			const updatedEntity = updatedEntityType[0]
-			for (const modelName of updatedEntity.model_names) {
-				await this._clearUserCachesForEntityTypeChange(orgCode, tenantCode, modelName, updatedEntity.value)
 			}
 
 			return responses.successResponse({
@@ -317,56 +303,6 @@ module.exports = class EntityHelper {
 				)
 			}
 
-			// THIRD: Remove individual entity type from cache
-			try {
-				// For each model this entity belonged to
-				if (entityToDelete.model_names && Array.isArray(entityToDelete.model_names)) {
-					for (const modelName of entityToDelete.model_names) {
-						// Remove the specific entity type cache
-						if (isDefaultOrg) {
-							await cacheHelper.entityTypes.deleteEntityTypesAcrossAllOrgs(
-								tenantCode,
-								modelName,
-								entityToDelete.value
-							)
-						} else {
-							await cacheHelper.entityTypes.delete(
-								tenantCode,
-								organizationCode,
-								modelName,
-								entityToDelete.value
-							)
-						}
-					}
-				}
-			} catch (cacheError) {
-				// Failed to perform selective cache removal - continue operation
-
-				// Fallback: retry removing only this specific entity's cache
-				if (entityToDelete.model_names && Array.isArray(entityToDelete.model_names)) {
-					for (const modelName of entityToDelete.model_names) {
-						try {
-							if (isDefaultOrg) {
-								await cacheHelper.entityTypes.deleteEntityTypesAcrossAllOrgs(
-									tenantCode,
-									modelName,
-									entityToDelete.value
-								)
-							} else {
-								await cacheHelper.entityTypes.delete(
-									tenantCode,
-									organizationCode,
-									modelName,
-									entityToDelete.value
-								)
-							}
-						} catch (retryError) {
-							// Failed to retry clear cache - continue operation
-						}
-					}
-				}
-			}
-
 			return responses.successResponse({
 				statusCode: httpStatusCode.accepted,
 				message: 'ENTITY_TYPE_DELETED_SUCCESSFULLY',
@@ -496,40 +432,17 @@ module.exports = class EntityHelper {
 			// Clear cache for deleted entities
 			try {
 				const defaultOrgCode = process.env.DEFAULT_ORGANISATION_CODE
-				const affectedModelNames = new Set()
-
 				for (const entityToDelete of entitiesToDelete) {
-					const modelNames = entityToDelete.model_names || []
 					const isDefaultOrg = entityToDelete.organization_code === defaultOrgCode
-					for (const modelName of modelNames) {
-						if (isDefaultOrg) {
-							await cacheHelper.entityTypes.deleteEntityTypesAcrossAllOrgs(
-								tenantCode,
-								modelName,
-								entityToDelete.value
-							)
-						} else {
-							await cacheHelper.entityTypes.delete(
-								tenantCode,
-								entityToDelete.organization_code,
-								modelName,
-								entityToDelete.value
-							)
-						}
-						affectedModelNames.add(modelName)
+					for (const modelName of entityToDelete.model_names || []) {
+						await this._clearUserCachesForEntityTypeChange(
+							entityToDelete.organization_code,
+							tenantCode,
+							modelName,
+							entityToDelete.value,
+							isDefaultOrg
+						)
 					}
-				}
-
-				// Clear user profile caches for affected models
-				const [menteeModelName, mentorModelName] = await Promise.all([
-					menteeExtensionQueries.getModelName(),
-					mentorExtensionQueries.getModelName(),
-				])
-				if (affectedModelNames.has(menteeModelName)) {
-					await cacheHelper.mentee.deleteAll(tenantCode).catch(() => {})
-				}
-				if (affectedModelNames.has(mentorModelName)) {
-					await cacheHelper.mentor.deleteAll(tenantCode).catch(() => {})
 				}
 			} catch (cacheError) {
 				console.log('Failed to clear cache for deleted entities:', cacheError.message)
@@ -587,13 +500,19 @@ module.exports = class EntityHelper {
 
 			// 2. Clear entity type cache for the specific model + value
 			if (modelName) {
-				clearPromises.push(
-					cacheHelper.entityTypes
-						.delete(tenantCode, organizationCode, modelName, entityValue)
-						.catch((error) => {
-							/* Failed to clear entity type cache - continue operation */
-						})
-				)
+				if (allOrgs) {
+					clearPromises.push(
+						cacheHelper.entityTypes
+							.deleteEntityTypesAcrossAllOrgs(tenantCode, modelName, entityValue)
+							.catch(() => {})
+					)
+				} else {
+					clearPromises.push(
+						cacheHelper.entityTypes
+							.delete(tenantCode, organizationCode, modelName, entityValue)
+							.catch(() => {})
+					)
+				}
 			}
 
 			// 3. Clear model-specific user caches based on the entity type model
@@ -649,10 +568,11 @@ module.exports = class EntityHelper {
 				}
 
 				if (modelName === sessionModelName) {
-					// For session model, we don't have session enumeration by org
-					// Session caches are typically cleared by individual session operations
-					// Entity types affecting sessions would be rare (custom session fields)
-					// Skip organization-wide session cache clearing to avoid performance impact
+					if (allOrgs) {
+						clearPromises.push(cacheHelper.sessions.deleteAll(tenantCode).catch(() => {}))
+					} else {
+						clearPromises.push(cacheHelper.sessions.deleteAll(tenantCode, organizationCode).catch(() => {}))
+					}
 				}
 			}
 

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -112,7 +112,7 @@ module.exports = class EntityHelper {
 						if (isDefaultOrg) {
 							// Default org update: other orgs may have cached this entity type via fallback
 							// under their own org key — sweep all of them
-							await cacheHelper.entityTypes.deleteAcrossAllOrgs(
+							await cacheHelper.entityTypes.deleteEntityTypesAcrossAllOrgs(
 								tenantCode,
 								modelName,
 								originalEntity.value

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -492,11 +492,11 @@ module.exports = class EntityHelper {
 			const clearPromises = []
 
 			// 1. Clear display properties cache (affects all users in org)
-			clearPromises.push(
-				cacheHelper.displayProperties.delete(tenantCode, organizationCode).catch((error) => {
-					/* Failed to clear display properties cache - continue operation */
-				})
-			)
+			if (allOrgs) {
+				clearPromises.push(cacheHelper.displayProperties.deleteAll(tenantCode).catch(() => {}))
+			} else {
+				clearPromises.push(cacheHelper.displayProperties.delete(tenantCode, organizationCode).catch(() => {}))
+			}
 
 			// 2. Clear entity type cache for the specific model + value
 			if (modelName) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Add cacheHelper.sessions.deleteAll(tenantCode, orgCode = null) to bulk-invalidate session caches scoped to an org or tenant-wide.
- Add cacheHelper.entityTypes.deleteEntityTypesAcrossAllOrgs(tenantCode, modelName, entityValue) to evict entity-type keys across all orgs in a tenant via Redis SCAN + delete.
- Add cacheHelper.mentor.deleteAll(tenantCode) and cacheHelper.mentee.deleteAll(tenantCode) to clear tenant-wide mentor/mentee profile caches.
- EntityHelper.update, EntityHelper.delete, and deleteEntityTypesAndEntities now compute whether the change is for the default organisation and pass an allOrgs flag to _clearUserCachesForEntityTypeChange to choose between org-scoped vs tenant-wide invalidation.
- _clearUserCachesForEntityTypeChange gained an allOrgs parameter; when true it:
  - uses cacheHelper.entityTypes.deleteEntityTypesAcrossAllOrgs(...) for entity-type cache sweeping,
  - uses cacheHelper.mentee.deleteAll/cacheHelper.mentor.deleteAll for mentee/mentor caches,
  - uses cacheHelper.sessions.deleteAll(tenantCode) for session caches.
- Stopped relying on updatedEntityType[0] for clearing user caches; cleanup decisions are driven by the original entity data and the allOrgs flag.
- getAllUsersByOrgId now computes the tenant view name before validating orgCodes so tenant-scoped logic can access the view name even when orgCodes is null/empty.
- Files changed: src/generics/cacheHelper.js, src/services/entity-type.js, src/database/queries/userExtension.js

## Contributions by Author

| Author | Added | Removed |
|--------|------:|--------:|
| borkarsaish65 | 105 | 97 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->