### PR TITLE
fix for value label in entity types

### DIFF
--- a/src/helpers/entityTypeCache.js
+++ b/src/helpers/entityTypeCache.js
@@ -162,7 +162,7 @@ async function getEntityTypesAndEntitiesWithCache(originalFilter, tenantCode, or
  * @name getEntityTypesAndEntitiesForModel
  * @param {String} modelName - model name to filter by
  * @param {String} tenantCode - user tenant code (single value, not array)
- * @param {String} orgCode - user organization code (single value, not array)
+ * @param {String|Array} orgCode - user organization code(s); single string or array — default org is always appended internally
  * @param {Object} additionalFilters - additional filter conditions
  * @returns {JSON} - Entity types with entities for the model
  */
@@ -238,9 +238,14 @@ async function getEntityTypesAndEntitiesForModel(modelName, tenantCode, orgCode,
 		let allEntityTypes = []
 		try {
 			// Step 1: ALWAYS fetch from user tenant and org codes
+			// Normalize orgCode: accept array or single string, always include default org
+			const orgCodeArray = Array.isArray(orgCode) ? [...orgCode] : [orgCode]
+			if (defaults.orgCode && !orgCodeArray.includes(defaults.orgCode)) {
+				orgCodeArray.push(defaults.orgCode)
+			}
 			const userFilter = {
 				status: 'ACTIVE',
-				organization_code: { [Op.in]: [orgCode, defaults.orgCode].filter(Boolean) },
+				organization_code: { [Op.in]: orgCodeArray.filter(Boolean) },
 				model_names: { [Op.contains]: [modelName] },
 			}
 			// Handle both array and single value for tenantCode

--- a/src/helpers/entityTypeCache.js
+++ b/src/helpers/entityTypeCache.js
@@ -240,7 +240,7 @@ async function getEntityTypesAndEntitiesForModel(modelName, tenantCode, orgCode,
 			// Step 1: ALWAYS fetch from user tenant and org codes
 			const userFilter = {
 				status: 'ACTIVE',
-				organization_code: orgCode,
+				organization_code: { [Op.in]: [orgCode, defaults.orgCode].filter(Boolean) },
 				model_names: { [Op.contains]: [modelName] },
 			}
 			// Handle both array and single value for tenantCode

--- a/src/helpers/getOrgIdAndEntityTypewithEntitiesBasedOnPolicy.js
+++ b/src/helpers/getOrgIdAndEntityTypewithEntitiesBasedOnPolicy.js
@@ -279,7 +279,7 @@ module.exports = class OrganizationAndEntityTypePolicyHelper {
 					entityTypesWithEntities = await entityTypeCache.getEntityTypesAndEntitiesForModel(
 						modelName,
 						tenantCode,
-						filter.organization_code[Op.in],
+						orgCodes[0],
 						{
 							allow_filtering: filter.allow_filtering,
 							has_entities: filter.has_entities,

--- a/src/helpers/getOrgIdAndEntityTypewithEntitiesBasedOnPolicy.js
+++ b/src/helpers/getOrgIdAndEntityTypewithEntitiesBasedOnPolicy.js
@@ -279,7 +279,7 @@ module.exports = class OrganizationAndEntityTypePolicyHelper {
 					entityTypesWithEntities = await entityTypeCache.getEntityTypesAndEntitiesForModel(
 						modelName,
 						tenantCode,
-						orgCodes[0],
+						filter.organization_code[Op.in],
 						{
 							allow_filtering: filter.allow_filtering,
 							has_entities: filter.has_entities,

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -356,11 +356,10 @@ module.exports = class EntityHelper {
 			if (entityType && entityType.length > 0) {
 				additionalFilters.value = entityType
 			}
-			const primaryOrgCode = orgCodes[0] || defaults.orgCode
 			let entityTypesWithEntities = await entityTypeCache.getEntityTypesAndEntitiesForModel(
 				Array.isArray(modelName) ? modelName[0] : modelName,
 				tenantCode,
-				primaryOrgCode,
+				orgCodes,
 				additionalFilters
 			)
 			entityTypesWithEntities = JSON.parse(JSON.stringify(entityTypesWithEntities))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- **Fixed entity type value label querying** - Updated `getEntityTypesAndEntitiesForModel` to accept `orgCode` as either a single string or an array, enabling multi-organization code filtering in entity type cache lookups
- **Improved multi-org entity filtering** - Modified entity type service to pass the full `orgCodes` array to the cache instead of only the primary organization, expanding query results to include all relevant organization codes including defaults

## Contribution Summary

| Author | Lines Added | Lines Removed |
|--------|-------------|--------------|
| borkarsaish65 | 8 | 4 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->