### PR TITLE
fix:cache/no cache session update/delete fix

### DIFF
--- a/src/services/mentees.js
+++ b/src/services/mentees.js
@@ -503,6 +503,9 @@ module.exports = class MenteesHelper {
 				})
 			}
 
+			// Normalize status that may be stored as processed {value, label} object in cache
+			sessionData.status = sessionData.status?.value ?? sessionData.status
+
 			const sessionAttendeeExist = sessionWithAttendee.attendee_id
 				? {
 						id: sessionWithAttendee.attendee_id,

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -599,6 +599,10 @@ module.exports = class SessionsHelper {
 				})
 			}
 
+			// Normalize fields that may be stored as processed {value, label} objects in cache
+			sessionDetail.status = sessionDetail.status?.value ?? sessionDetail.status
+			sessionDetail.type = sessionDetail.type?.value ?? sessionDetail.type
+
 			// let triggerSessionMeetinkAddEmail = false
 			// if (
 			// 	sessionDetail.meeting_info &&

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1469,6 +1469,14 @@ module.exports = class SessionsHelper {
 
 			if (utils.isNumeric(id) && sessionDetailedResponse) {
 				try {
+					// Normalize fields that may be stored as processed {value, label} objects in cache
+					sessionDetailedResponse.type = sessionDetailedResponse.type?.value ?? sessionDetailedResponse.type
+
+					let sessionAttendee = sessionDetailedResponse.mentees?.find(
+						(mentee) => String(mentee.id) === String(userId)
+					)
+					sessionDetailedResponse.is_enrolled = userId && sessionAttendee ? true : false
+
 					// Check accessibility for cached response
 					if (userId !== '' && isAMentor !== '') {
 						let isAccessible = await this.checkIfSessionIsAccessible(
@@ -1486,10 +1494,6 @@ module.exports = class SessionsHelper {
 							})
 						}
 					}
-
-					let sessionAttendee = sessionDetailedResponse.mentees?.find(
-						(mentee) => String(mentee.id) === String(userId)
-					)
 
 					if (!sessionAttendee) {
 						let validateDefaultRules
@@ -1521,9 +1525,7 @@ module.exports = class SessionsHelper {
 						}
 					}
 
-					sessionDetailedResponse.is_enrolled = false
 					if (userId && sessionAttendee) {
-						sessionDetailedResponse.is_enrolled = true
 						sessionDetailedResponse.enrolment_type = sessionAttendee.type
 					}
 
@@ -2061,6 +2063,9 @@ module.exports = class SessionsHelper {
 					responseCode: 'CLIENT_ERROR',
 				})
 			}
+
+			// Normalize fields that may be stored as processed {value, label} objects in cache
+			session.type = session.type?.value ?? session.type
 
 			let validateDefaultRules
 			if (isSelfEnrolled) {

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1469,8 +1469,7 @@ module.exports = class SessionsHelper {
 
 			if (utils.isNumeric(id) && sessionDetailedResponse) {
 				try {
-					// Normalize fields that may be stored as processed {value, label} objects in cache
-					sessionDetailedResponse.type = sessionDetailedResponse.type?.value ?? sessionDetailedResponse.type
+					const sessionTypeValue = sessionDetailedResponse.type?.value ?? sessionDetailedResponse.type
 
 					let sessionAttendee = sessionDetailedResponse.mentees?.find(
 						(mentee) => String(mentee.id) === String(userId)
@@ -1480,7 +1479,7 @@ module.exports = class SessionsHelper {
 					// Check accessibility for cached response
 					if (userId !== '' && isAMentor !== '') {
 						let isAccessible = await this.checkIfSessionIsAccessible(
-							sessionDetailedResponse,
+							{ ...sessionDetailedResponse, type: sessionTypeValue },
 							userId,
 							isAMentor,
 							tenantCode,
@@ -1504,7 +1503,7 @@ module.exports = class SessionsHelper {
 								requesterId: userId,
 								roles: roles,
 								requesterOrganizationCode: orgCode,
-								data: sessionDetailedResponse,
+								data: { ...sessionDetailedResponse, type: sessionTypeValue },
 								tenantCode: tenantCode,
 							})
 						}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Normalize session.status in joinSession (src/services/mentees.js) to use primitive value when cached as { value, label } so status comparisons work reliably.
- Normalize sessionDetail.status and sessionDetail.type in SessionsHelper.update (src/services/sessions.js) to use primitive values for consistent update validation.
- In SessionsHelper.details (cache-hit path), compute is_enrolled directly from the mentees list by matching userId and remove the prior default-reset pattern; normalize type before validations and payload construction.
- Normalize session.type in SessionsHelper.enroll (src/services/sessions.js) from cached object form to its primitive value before default-rule validation and permission checks.

## Changes by Author

| Author | Lines Added | Lines Removed |
|--------|------------:|-------------:|
| borkarsaish65 | 19 | 8 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->