### PR TITLE
Fix/org event

### DIFF
--- a/src/.env.sample
+++ b/src/.env.sample
@@ -193,3 +193,4 @@ SERVICE_NAME='MentoringService'
 #To disable logs for healthCheck
 HEALTH_CHECK_DEBUG_MODE='false'
 EVENT_TENANT_KAFKA_TOPIC='tenantEvent'
+EVENT_ORGANIZATION_KAFKA_TOPIC='organizationEvent'

--- a/src/configs/kafka.js
+++ b/src/configs/kafka.js
@@ -53,6 +53,7 @@ async function startConsumer(kafkaClient) {
 		process.env.EVENTS_TOPIC,
 		process.env.CLEAR_INTERNAL_CACHE,
 		process.env.EVENT_TENANT_KAFKA_TOPIC,
+		process.env.EVENT_ORGANIZATION_KAFKA_TOPIC,
 	].filter(Boolean)
 	await consumer.subscribe({ topics })
 
@@ -88,8 +89,7 @@ async function startConsumer(kafkaClient) {
 					}
 				}
 
-				if (payload && topic === process.env.EVENTS_TOPIC) {
-					// Handle organization events
+				if (payload && topic === process.env.EVENT_ORGANIZATION_KAFKA_TOPIC) {
 					if (
 						payload.entity === 'organization' &&
 						(payload.eventType === 'create' ||
@@ -98,6 +98,9 @@ async function startConsumer(kafkaClient) {
 					) {
 						response = await organizationConsumer.messageReceived(payload)
 					}
+				}
+
+				if (payload && topic === process.env.EVENTS_TOPIC) {
 					if (payload.entity === 'user') {
 						if (payload.eventType === 'roleChange') {
 							response = await rolechangeConsumer.messageReceived(payload)

--- a/src/envVariables.js
+++ b/src/envVariables.js
@@ -602,6 +602,11 @@ let enviromentVariables = {
 		optional: true,
 		default: 'tenantEvent',
 	},
+	EVENT_ORGANIZATION_KAFKA_TOPIC: {
+		message: 'Required kafka topic for organization events',
+		optional: true,
+		default: 'organizationEvent',
+	},
 	SERVICE_NAME: {
 		message: 'Required SERVICE_NAME to handling health check',
 		optional: true,

--- a/src/generics/kafka/consumers/organization.js
+++ b/src/generics/kafka/consumers/organization.js
@@ -30,7 +30,7 @@ var messageReceived = function (message) {
 					// Use existing createOrgExtension method from organization service
 					const createEventBody = {
 						entityId: entityId.toString(),
-						organization_code: code,
+						code: code,
 						name: name,
 						description: description,
 						status: status,

--- a/src/services/organization.js
+++ b/src/services/organization.js
@@ -74,7 +74,7 @@ module.exports = class OrganizationService {
 			const extensionData = {
 				...common.getDefaultOrgPolicies(),
 				organization_id: eventBody.entityId,
-				organization_code: eventBody.code,
+				organization_code: eventBody.organization_code,
 				created_by: eventBody.created_by,
 				updated_by: eventBody.created_by,
 				name: eventBody.name,

--- a/src/services/organization.js
+++ b/src/services/organization.js
@@ -74,7 +74,7 @@ module.exports = class OrganizationService {
 			const extensionData = {
 				...common.getDefaultOrgPolicies(),
 				organization_id: eventBody.entityId,
-				organization_code: eventBody.organization_code,
+				organization_code: eventBody.code,
 				created_by: eventBody.created_by,
 				updated_by: eventBody.created_by,
 				name: eventBody.name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Added `EVENT_ORGANIZATION_KAFKA_TOPIC` environment variable configuration with default value `organizationEvent` to support organization event Kafka messaging
- Added `EVENT_ORGANIZATION_KAFKA_TOPIC` to `.env.sample` with the default value for reference
- Updated organization Kafka consumer to use `code` field instead of `organization_code` in event payloads for consistency

## Author Contributions

| Author | Lines Added | Lines Removed |
|--------|------------|--------------|
| borkarsaish65 | 8 | 2 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->