### PR TITLE
fix

### DIFF
--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -71,7 +71,6 @@ module.exports = class NotificationTemplateHelper {
 	static async update(id, bodyData, tokenInformation, tenantCode) {
 		try {
 			let filter = {
-				organization_id: tokenInformation.organization_id,
 				organization_code: tokenInformation.organization_code,
 				tenant_code: tenantCode,
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Fixed notification template update filter logic: query filtering now uses organization_code and tenant_code instead of organization_id while still setting bodyData.organization_id on update
- Cache invalidation behavior remains based on organization_code, including deletion logic for default organization templates

## Lines Changed by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| borkarsaish65 | 0 | 1 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->