### PR TITLE
PR for entity type value label resolution

### DIFF
--- a/src/database/queries/sessions.js
+++ b/src/database/queries/sessions.js
@@ -1150,6 +1150,8 @@ exports.findAllSessions = async (page, limit, search, filters, tenantCode) => {
 				'created_at',
 				'meeting_info',
 				'created_by',
+				'mentor_organization_id',
+				'meta',
 			],
 			offset: parseInt((page - 1) * limit, 10),
 			limit: parseInt(limit, 10),

--- a/src/helpers/getEnrolledMentees.js
+++ b/src/helpers/getEnrolledMentees.js
@@ -67,14 +67,15 @@ exports.getEnrolledMentees = async (sessionId, queryParams, tenantCode) => {
 		}
 
 		// Process entity types to add value labels
-		const uniqueOrgIds = [...new Set(enrolledUsers.map((user) => user.organization_id))]
+		// organization_code is directly available on each user from getUserDetailedListUsingCache
+		const uniqueOrgCodes = [...new Set(enrolledUsers.map((user) => user.organization_code).filter(Boolean))]
 		const modelName = await menteeExtensionQueries.getModelName()
 
 		const processedUsers = await entityTypeService.processEntityTypesToAddValueLabels(
 			enrolledUsers,
-			uniqueOrgIds,
+			uniqueOrgCodes,
 			[modelName],
-			'organization_id',
+			'organization_code',
 			[],
 			tenantCode
 		)

--- a/src/helpers/getEnrolledMentees.js
+++ b/src/helpers/getEnrolledMentees.js
@@ -67,7 +67,6 @@ exports.getEnrolledMentees = async (sessionId, queryParams, tenantCode) => {
 		}
 
 		// Process entity types to add value labels
-		// organization_code is directly available on each user from getUserDetailedListUsingCache
 		const uniqueOrgCodes = [...new Set(enrolledUsers.map((user) => user.organization_code).filter(Boolean))]
 		const modelName = await menteeExtensionQueries.getModelName()
 

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -4,6 +4,7 @@ const entityTypeQueries = require('../database/queries/entityType')
 const menteeExtensionQueries = require('../database/queries/userExtension')
 const mentorExtensionQueries = require('../database/queries/mentorExtension')
 const sessionQueries = require('../database/queries/sessions')
+const organisationExtensionQueries = require('../database/queries/organisationExtension')
 const { UniqueConstraintError } = require('sequelize')
 const { Op } = require('sequelize')
 const { removeDefaultOrgEntityTypes } = require('@generics/utils')
@@ -317,10 +318,12 @@ module.exports = class EntityHelper {
 	 * @method
 	 * @name processEntityTypesToAddValueLabels
 	 * @param {Array} responseData 				- data to modify
-	 * @param {Array} orgCods					- org ids
+	 * @param {Array} orgCodes					- org ids or org codes depending on orgIdPassed
 	 * @param {String} modelName 				- model name which the entity search is associated to.
-	 * @param {String} orgCodeKey 				- In responseData which key represents org id
+	 * @param {String} orgCodeKey 				- In responseData which key represents org identifier
 	 * @param {ARRAY} entityType 				- Array of entity types value
+	 * @param {String} tenantCode				- tenant code
+	 * @param {Boolean} orgIdPassed				- true when orgCodes contains integer org IDs instead of org code strings
 	 * @returns {JSON} 							- modified response data
 	 */
 	static async processEntityTypesToAddValueLabels(
@@ -329,7 +332,8 @@ module.exports = class EntityHelper {
 		modelName,
 		orgCodeKey,
 		entityType,
-		tenantCode
+		tenantCode,
+		orgIdPassed = false
 	) {
 		try {
 			const defaults = await getDefaults()
@@ -346,8 +350,24 @@ module.exports = class EntityHelper {
 					responseCode: 'CLIENT_ERROR',
 				})
 
-			if (!orgCodes.includes(defaults.orgCode)) {
-				orgCodes.push(defaults.orgCode)
+			// When callers pass integer org IDs instead of org code strings, resolve them first
+			let idToCodeMap = null
+			let resolvedOrgCodes = orgCodes
+			if (orgIdPassed) {
+				const validIds = orgCodes.filter(Boolean)
+				const orgExtensions = await organisationExtensionQueries.findAll(
+					{ organization_id: { [Op.in]: validIds }, tenant_code: tenantCode },
+					{ attributes: ['organization_id', 'organization_code'] }
+				)
+				idToCodeMap = {}
+				orgExtensions.forEach((ext) => {
+					idToCodeMap[ext.organization_id] = ext.organization_code
+				})
+				resolvedOrgCodes = [...new Set(Object.values(idToCodeMap))]
+			}
+
+			if (!resolvedOrgCodes.includes(defaults.orgCode)) {
+				resolvedOrgCodes = [...resolvedOrgCodes, defaults.orgCode]
 			}
 
 			const additionalFilters = {
@@ -359,7 +379,7 @@ module.exports = class EntityHelper {
 			let entityTypesWithEntities = await entityTypeCache.getEntityTypesAndEntitiesForModel(
 				Array.isArray(modelName) ? modelName[0] : modelName,
 				tenantCode,
-				orgCodes,
+				resolvedOrgCodes,
 				additionalFilters
 			)
 			entityTypesWithEntities = JSON.parse(JSON.stringify(entityTypesWithEntities))
@@ -369,8 +389,14 @@ module.exports = class EntityHelper {
 
 			// Use Array.map with async to process each element asynchronously
 			const result = responseData.map(async (element) => {
-				// Prepare the array of orgCodes to search
-				const orgIdToSearch = [element[orgCodeKey], defaults.orgCode]
+				// Resolve per-element org code (handles both integer ID and string code cases)
+				const elementOrgIdentifier = element[orgCodeKey]
+				const elementOrgCode = idToCodeMap ? idToCodeMap[elementOrgIdentifier] : elementOrgIdentifier
+
+				// Build org codes to search — only include elementOrgCode if resolved; defaults.orgCode always last
+				const orgIdToSearch = []
+				if (elementOrgCode) orgIdToSearch.push(elementOrgCode)
+				orgIdToSearch.push(defaults.orgCode)
 
 				// Filter entity types based on orgCodes and remove parent entity types
 				let entitTypeData = entityTypesWithEntities.filter((obj) =>

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -393,7 +393,6 @@ module.exports = class EntityHelper {
 				const elementOrgIdentifier = element[orgCodeKey]
 				const elementOrgCode = idToCodeMap ? idToCodeMap[elementOrgIdentifier] : elementOrgIdentifier
 
-				// Build org codes to search — only include elementOrgCode if resolved; defaults.orgCode always last
 				const orgIdToSearch = []
 				if (elementOrgCode) orgIdToSearch.push(elementOrgCode)
 				orgIdToSearch.push(defaults.orgCode)

--- a/src/services/entity-type.js
+++ b/src/services/entity-type.js
@@ -411,7 +411,7 @@ module.exports = class EntityHelper {
 			})
 			return Promise.all(result)
 		} catch (err) {
-			return err
+			throw err
 		}
 	}
 

--- a/src/services/mentees.js
+++ b/src/services/mentees.js
@@ -726,7 +726,8 @@ module.exports = class MenteesHelper {
 				common.sessionModelName,
 				'mentor_organization_id',
 				[],
-				tenantCode
+				tenantCode,
+				true
 			)
 		}
 
@@ -879,7 +880,8 @@ module.exports = class MenteesHelper {
 					common.sessionModelName,
 					'mentor_organization_id',
 					[],
-					tenantCode
+					tenantCode,
+					true
 				)
 				sessionDetails.rows = await this.sessionMentorDetails(sessionDetails.rows, tenantCode)
 				sessionDetails.rows = sessionDetails.rows.map((r) => ({ ...r, is_enrolled: true }))

--- a/src/services/mentors.js
+++ b/src/services/mentors.js
@@ -162,7 +162,8 @@ module.exports = class MentorsHelper {
 				common.sessionModelName,
 				'mentor_organization_id',
 				[],
-				tenantCode
+				tenantCode,
+				true
 			)
 
 			upcomingSessions.data = await this.sessionMentorDetails(upcomingSessions.data, tenantCode)
@@ -1741,18 +1742,18 @@ module.exports = class MentorsHelper {
 					}
 				}
 				item.is_assigned = item.mentor_id !== item.created_by
+				// Normalize org code from enriched organization object for entity type resolution
+				item.organization_code = item.organization?.organization_code || null
 			})
 
 			// Extract organization codes for entity processing
-			const uniqueOrgIds = [
-				...new Set(sessionDetails.rows.map((obj) => obj.organization?.organization_code).filter(Boolean)),
-			]
+			const uniqueOrgCodes = [...new Set(sessionDetails.rows.map((obj) => obj.organization_code).filter(Boolean))]
 
 			sessionDetails.rows = await entityTypeService.processEntityTypesToAddValueLabels(
 				sessionDetails.rows,
-				uniqueOrgIds,
+				uniqueOrgCodes,
 				common.sessionModelName,
-				'mentor_organization_id',
+				'organization_code',
 				[],
 				tenantCode
 			)

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -3242,7 +3242,8 @@ module.exports = class SessionsHelper {
 				common.sessionModelName,
 				'mentor_organization_id',
 				[],
-				tenantCode
+				tenantCode,
+				true
 			)
 
 			await Promise.all(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Added mentor_organization_id and meta fields to session query results in findAllSessions
- Switched entity type value-label resolution to use organization codes (organization_code) instead of organization IDs in lookups
- Added orgIdPassed flag to EntityHelper.processEntityTypesToAddValueLabels to support resolving org IDs to org codes
- Updated calls across mentee, mentor, and session services to pass orgIdPassed=true where org IDs are provided
- Normalized organization_code on session/createdSessions items from nested organization objects

## Lines Changed by Author

| Author | Added | Removed |
|--------|------:|--------:|
| borkarsaish65 | 52 | 20 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->