### PR TITLE
Fix/cache org policy

### DIFF
--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -1825,7 +1825,7 @@ module.exports = class AdminService {
 			try {
 				const orgData = await orgQueries.findOne({ organization_code: orgCode }, tenantCode)
 				if (orgData) {
-					await cacheHelper.organizations.set(tenantCode, orgCode, orgCode, orgData)
+					await cacheHelper.organizations.set(tenantCode, orgCode, orgData.organization_id, orgData)
 					warmupResults.organizations = 1
 				}
 			} catch (error) {

--- a/src/services/mentees.js
+++ b/src/services/mentees.js
@@ -90,6 +90,7 @@ module.exports = class MenteesHelper {
 		}
 
 		delete mentee.user_id
+		const visibleToOrganizations = mentee.visible_to_organizations
 		delete mentee.visible_to_organizations
 
 		const defaults = await getDefaults()
@@ -230,7 +231,7 @@ module.exports = class MenteesHelper {
 			user_id: id, // Add user_id to match mentor read response
 			...sanitizedMenteeData,
 			...processDbResponse,
-			visible_to_organizations: mentee.visible_to_organizations, // Add to match mentor read
+			visible_to_organizations: visibleToOrganizations, // Add to match mentor read
 			settings: mentee.settings, // Add settings to match mentor read
 			displayProperties,
 		}

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -317,6 +317,11 @@ module.exports = class OrgAdminService {
 					{ organization_id: decodedToken.organization_id }, //custom filter for where clause
 					tenantCode
 				)
+
+				// Clear per-user profile caches so stale policy fields are not served after bulk update
+				await cacheHelper.mentee.deleteAll(tenantCode)
+				await cacheHelper.mentor.deleteAll(tenantCode)
+
 				// commenting as part of first level SAAS changes. will need this in the code next level
 				// await sessionQueries.updateSession(
 				// 	{
@@ -672,12 +677,20 @@ module.exports = class OrgAdminService {
 				await menteeQueries.removeVisibleToOrg(orgId, deltaOrganizationIds, tenantCode)
 			}
 
+			// Clear per-user profile caches — visible_to_organizations field is cached in mentee/mentor profiles
+			try {
+				await cacheHelper.mentee.deleteAll(tenantCode)
+				await cacheHelper.mentor.deleteAll(tenantCode)
+			} catch (cacheError) {
+				console.error('Failed to invalidate mentee/mentor caches after updateRelatedOrgs:', cacheError)
+			}
+
 			// Invalidate organization cache for the affected organization
 			try {
 				// Get organization details to extract orgCode for cache invalidation
 				const organizationDetails = await userRequests.fetchOrgDetails({ organizationId: orgId, tenantCode })
-				if (organizationDetails.success && organizationDetails.data && organizationDetails.data.result) {
-					const orgCode = organizationDetails.data.result.organization_code || orgId
+				const orgCode = organizationDetails?.data?.result?.code
+				if (orgCode) {
 					await cacheHelper.organizations.delete(tenantCode, orgCode, orgId)
 				}
 			} catch (cacheError) {

--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -317,11 +317,13 @@ module.exports = class OrgAdminService {
 					{ organization_id: decodedToken.organization_id }, //custom filter for where clause
 					tenantCode
 				)
-
 				// Clear per-user profile caches so stale policy fields are not served after bulk update
-				await cacheHelper.mentee.deleteAll(tenantCode)
-				await cacheHelper.mentor.deleteAll(tenantCode)
-
+				try {
+					await cacheHelper.mentee.deleteAll(tenantCode)
+					await cacheHelper.mentor.deleteAll(tenantCode)
+				} catch (cacheError) {
+					console.error('Failed to invalidate mentee/mentor caches after setOrgPolicies:', cacheError)
+				}
 				// commenting as part of first level SAAS changes. will need this in the code next level
 				// await sessionQueries.updateSession(
 				// 	{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Use `organization_id` as the cache key when warming the organizations cache to ensure lookups match the warmup entry
- Preserve `visible_to_organizations` in mentee profile responses by saving it before deleting and restoring it to the final response
- Invalidate all per-tenant mentee and mentor profile caches after organization policy changes (`setOrgPolicies`)
- Invalidate all per-tenant mentee and mentor profile caches after organization relationship updates (`updateRelatedOrgs`)
- Improve organization-code extraction for cache invalidation using optional chaining (`organizationDetails?.data?.result?.code`) and only delete org cache when a valid code is present

## Contributions by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| borkarsaish65 | 20 | 4 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->