### PR TITLE
Broken Mentor list for org policy Fix

### DIFF
--- a/src/services/mentors.js
+++ b/src/services/mentors.js
@@ -1628,7 +1628,7 @@ module.exports = class MentorsHelper {
 
 					filter =
 						additionalFilter +
-						`AND ( ('${userPolicyDetails.organization_code}' = ANY("visible_to_organizations") AND "mentor_visibility" != 'CURRENT')`
+						`AND ( ('${userPolicyDetails.organization_id}' = ANY("visible_to_organizations") AND "mentor_visibility" != 'CURRENT')`
 
 					if (additionalFilter.length === 0)
 						filter += ` OR organization_code = '${userPolicyDetails.organization_code}' )`
@@ -1640,7 +1640,7 @@ module.exports = class MentorsHelper {
 					 */
 					filter =
 						additionalFilter +
-						`AND (('${userPolicyDetails.organization_code}' = ANY("visible_to_organizations") AND "mentor_visibility" != 'CURRENT' ) OR "mentor_visibility" = 'ALL' OR "organization_code" = '${userPolicyDetails.organization_code}')`
+						`AND (('${userPolicyDetails.organization_id}' = ANY("visible_to_organizations") AND "mentor_visibility" != 'CURRENT' ) OR "mentor_visibility" = 'ALL' OR "organization_code" = '${userPolicyDetails.organization_code}')`
 				}
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Update: In the mentors service, `filterMentorListBasedOnSaasPolicy` now compares `userPolicyDetails.organization_id` (instead of `organization_code`) against `visible_to_organizations` for ASSOCIATED and ALL external mentor visibility policies. Fallback/or logic still preserves comparisons involving `organization_code` where present.

## Lines Changed by Author

| Author | Email | Lines Added | Lines Removed |
|--------|-------|-------------|---------------|
| borkarsaish65 | borkarsaish65@gmail.com | 2 | 2 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->