### PR TITLE
fix:setpolicy update function corrected

### DIFF
--- a/src/services/org-admin.js
+++ b/src/services/org-admin.js
@@ -294,9 +294,9 @@ module.exports = class OrgAdminService {
 
 				if (
 					policyData?.external_mentor_visibility == common.ASSOCIATED ||
-					policyData?.mentor_visibility_policy == common.ASSOCIATED ||
+					policyData?.mentor_visibility == common.ASSOCIATED ||
 					policyData?.external_mentee_visibility == common.ASSOCIATED ||
-					policyData?.mentee_visibility_policy == common.ASSOCIATED
+					policyData?.mentee_visibility == common.ASSOCIATED
 				) {
 					const organizationDetails = await userRequests.fetchOrgDetails({
 						organizationId: decodedToken.organization_id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Fixed conditional field name references in OrgAdminService.setOrgPolicies() to correctly check `mentor_visibility` and `mentee_visibility` when deciding to recompute and propagate organization visibility and extension policy updates.

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| borkarsaish65 | 2 | 2 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->