### PR TITLE
fix: mark session as completed via scheduler call

### DIFF
--- a/src/controllers/v1/notifications.js
+++ b/src/controllers/v1/notifications.js
@@ -34,7 +34,7 @@ module.exports = class Notifications {
 			notificationsService.sendNotification(
 				req.body.job_id,
 				req.body.email_template_code,
-				req.body.job_creator_org_id ? req.body.job_creator_org_id : '',
+				req.body.org_code || '',
 				tenantCode
 			)
 			return {

--- a/src/controllers/v1/sessions.js
+++ b/src/controllers/v1/sessions.js
@@ -241,15 +241,25 @@ module.exports = class Sessions {
 		try {
 			let tenantCode = req.decodedToken?.tenant_code
 			let orgCode = req.decodedToken?.organization_code
+
+			// For scheduler service callbacks: tenant_code and org_code come in the request body
+			if (!tenantCode && req.body?.tenant_code) {
+				tenantCode = req.body.tenant_code
+			}
+			if (!orgCode && req.body?.org_code) {
+				orgCode = req.body.org_code
+			}
+
 			// Enhanced: Check query parameters first (from BBB callback with enhanced isolation)
 			if (!tenantCode && req.query.tenantCode) {
 				tenantCode = req.query.tenantCode
 			}
 
-			// For scheduled jobs or BBB callbacks without tokens, get tenant_code from session
-			if (!tenantCode) {
-				const sessionData = await sessionService.getSessionTenantCode(req.params.id, tenantCode)
-				tenantCode = sessionData?.tenant_code
+			// For BBB callbacks or any other case without tokens/body — fetch from session
+			if (!tenantCode || !orgCode) {
+				const sessionData = await sessionService.getSessionTenantCode(req.params.id, orgCode)
+				if (!tenantCode) tenantCode = sessionData?.tenant_code
+				if (!orgCode) orgCode = sessionData?.org_code
 			}
 
 			const isBBB = req.query.source == common.BBB_VALUE ? true : false

--- a/src/database/queries/sessions.js
+++ b/src/database/queries/sessions.js
@@ -284,7 +284,7 @@ exports.getSessionTenantCode = async (sessionId) => {
 	try {
 		return await Session.findOne({
 			where: { id: sessionId },
-			attributes: ['id', 'tenant_code'],
+			attributes: ['id', 'tenant_code', 'mentor_organization_id'],
 			raw: true,
 		})
 	} catch (error) {

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -490,6 +490,7 @@ module.exports = class SessionsHelper {
 					email_template_code: jobsToCreate[jobIndex].emailTemplate,
 					job_creator_org_id: orgId,
 					tenant_code: tenantCode,
+					org_code: orgCode,
 				}
 				// Create the scheduler job with the calculated delay and other parameters
 				console.log('📧 EMAIL DEBUG: Creating scheduler job:', {
@@ -2750,9 +2751,24 @@ module.exports = class SessionsHelper {
 	 * @param {String} sessionId - session id.
 	 * @returns {Object} - session data with tenant_code.
 	 */
-	static async getSessionTenantCode(sessionId, tenantCode) {
+	static async getSessionTenantCode(sessionId, orgCode = null) {
 		try {
-			return await sessionQueries.findSessionForPublicEndpoint(sessionId, tenantCode)
+			const session = await sessionQueries.getSessionTenantCode(sessionId)
+			if (!session) return null
+
+			if (!orgCode && session.mentor_organization_id && session.tenant_code) {
+				const orgExtension = await organisationExtensionQueries.findOne(
+					{ organization_id: session.mentor_organization_id },
+					session.tenant_code,
+					{ attributes: ['organization_code'], raw: true }
+				)
+				orgCode = orgExtension?.organization_code || null
+			}
+
+			return {
+				tenant_code: session.tenant_code,
+				org_code: orgCode,
+			}
 		} catch (error) {
 			throw error
 		}

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -2745,11 +2745,13 @@ module.exports = class SessionsHelper {
 	}
 
 	/**
-	 * Get session tenant code for public endpoints
+	 * Get session tenant code and org code for public/internal endpoints.
+	 * Resolves org_code via org extension lookup if not provided.
 	 * @method
 	 * @name getSessionTenantCode
 	 * @param {String} sessionId - session id.
-	 * @returns {Object} - session data with tenant_code.
+	 * @param {String|null} orgCode - org code if already known, null to trigger lookup.
+	 * @returns {Object} - { tenant_code, org_code }
 	 */
 	static async getSessionTenantCode(sessionId, orgCode = null) {
 		try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Enhanced tenant and organization code resolution in the completed session endpoint: prefer decoded token, then request body, and fetch session data when either code is missing
- Broadened session lookup to return both tenant_code and org_code from session data when needed
- Added mentor_organization_id to session tenant code query to enable org_code resolution
- Updated SessionsHelper.getSessionTenantCode to accept optional orgCode and return { tenant_code, org_code } (or null if session not found)
- Resolve org_code via organisation extension lookup using session.mentor_organization_id when orgCode not provided
- Include org_code in scheduler job payloads for session-creation notification scheduling
- Use org_code (req.body.org_code) instead of job_creator_org_id when calling notificationsService.sendNotification

## Lines Changed by Author

| Author | Additions | Deletions |
|--------|-----------:|----------:|
| borkarsaish65 | 25 | 37 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->