### PR TITLE
fix: remove user_roles from cached response in getInfo connections API

### DIFF
--- a/src/services/connections.js
+++ b/src/services/connections.js
@@ -127,7 +127,9 @@ module.exports = class ConnectionHelper {
 			// Use getCacheOnly first, then fallback to database query if cache miss
 			let userDetails = await cacheHelper.mentee.getCacheOnly(tenantCode, friendId)
 
-			if (!userDetails) {
+			if (userDetails) {
+				delete userDetails.user_roles
+			} else {
 				userDetails = await userExtensionQueries.getMenteeExtension(
 					friendId,
 					[


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Sanitize cached mentee extension data by removing the `user_roles` field in the `getInfo` API response when data is retrieved from cache
- Maintain database fallback behavior for cache misses, preserving existing functionality when cache data is unavailable

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| sumanvpacewisdom | 3 | 1 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->